### PR TITLE
fix: Update README files with correct links and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm start
 npm run start:local
 ```
 
-The documentation will be available at `http://localhost:3000` (or port 3023 if using `start:local`)
+The documentation will be available at `http://localhost:3023`
 
 ### Building for Production
 
@@ -159,23 +159,24 @@ If you notice errors, have different perspectives, or want to contribute feedbac
 
 This repository contains documentation in two locations:
 
-1. **Root Directory** (`00_Eco_Balance_Hub.md`, `01_Executive_Summary.md`, etc.)
+1. **Root Directory** (`00_Eco_Balance_Hub.md`, `strategic/` folder)
    - Original source files with Obsidian-style links
+   - Strategic documents in `strategic/` folder
+   - Restoration playbook in `strategic/restoration_playbook/`
    - May be used with Obsidian or other markdown tools
-   - Currently contains older content
 
 2. **`docs/` Directory** (Docusaurus site)
    - Organized in subdirectories for the public website
    - Uses standard markdown links
-   - Contains updated, current content
+   - Contains synced content from root files
    - **This is the source for the Docusaurus website**
 
 **⚠️ Important:** 
-- **Root files are the source of truth** - Edit these files
-- **`docs/` files are generated** - Don't edit directly, they're synced from root
-- **Sync process:** Run `npm run sync` after editing root files to update `docs/`
+- **Root files are the source of truth** - Edit files in root or `strategic/` folder
+- **`docs/` files are synced** - Run `node scripts/sync-docs.js` after editing root files
+- **Restoration playbook** is synced from `strategic/restoration_playbook/` to `docs/restoration-playbook/`
 
-See [DOCUMENTATION_STRUCTURE.md](./DOCUMENTATION_STRUCTURE.md) for details on the sync process.
+See [DOCUMENTATION_STRUCTURE.md](_process/documentation/DOCUMENTATION_STRUCTURE.md) for details on the sync process.
 
 ---
 
@@ -211,20 +212,20 @@ eco-balance-documentation/
 - `npm start` - Start development server
 - `npm run build` - Build for production
 - `npm run serve` - Serve built site
-- `npm run sync` or `npm run sync:docs` - Sync root files to `docs/` directory
+- `node scripts/sync-docs.js` - Sync root files to `docs/` directory
 - `npm test` - Run tests (link checking, build validation)
 - `npm run test:links` - Check all internal links
 - `npm run test:build` - Validate build
 
 ### Documentation Workflow
 
-1. **Edit root files** (source of truth) - Files like `00_Eco_Balance_Hub.md`, `01_Executive_Summary.md`, etc.
-2. **Run sync** - `npm run sync` to convert and update `docs/` files
+1. **Edit root files** (source of truth) - Files in `strategic/` folder or root
+2. **Run sync** - `node scripts/sync-docs.js` to convert and update `docs/` files
 3. **Build site** - `npm run build` to generate the Docusaurus site
 4. **Test** - `npm test` to verify links and build
 
 The sync script automatically:
-- Converts Obsidian-style links (``) to Docusaurus links
+- Converts Obsidian-style links (`[[...]]`) to Docusaurus links
 - Adds appropriate frontmatter (id, title, sidebar_position)
 - Preserves all content
 
@@ -284,9 +285,9 @@ Please note that this documentation is primarily maintained by the project found
 
 ## 🔗 Links
 
-- **Project Documentation:** [Link to deployed site if available]
-- **Repository:** [GitHub repository URL]
-- **Contact:** [Add contact information if desired]
+- **Project Documentation:** [View on GitHub Pages](https://presiannedyalkov.github.io/eco-balance-documentation/) (when deployed)
+- **Repository:** [GitHub Repository](https://github.com/presiannedyalkov/eco-balance-documentation)
+- **Restoration Playbook:** [Restoration Playbook Template](/restoration-playbook/README) - Template for ecological restoration projects
 
 ---
 

--- a/docs/restoration-playbook/README.md
+++ b/docs/restoration-playbook/README.md
@@ -94,15 +94,15 @@ This is a **comprehensive template and playbook** for ecological restoration pro
 ### Phase 1: Site Selection (9 Tasks)
 **Purpose:** Find and evaluate locations with highest restoration potential
 
-1. **[Site Selection Overview](site_selection/00_Site_Selection_Overview)** - Strategic framework
-2. **[Identify Potential Locations](site_selection/01_Identify_Potential_Locations)** - Geographic analysis
-3. **[Evaluate Land Condition](site_selection/02_Evaluate_Land_Condition)** - Site assessment
-4. **[Estimate Restoration Potential](site_selection/03_Estimate_Restoration_Potential)** - Feasibility analysis
-5. **[Consider Accessibility](site_selection/04_Consider_Accessibility)** - Practical access
-6. **[Research Local Regulations](site_selection/05_Research_Local_Regulations)** - Legal compliance
-7. **[Contact Landowners](site_selection/06_Contact_Landowners)** - Relationship building
-8. **[Visit Sites](site_selection/07_Visit_Sites)** - Ground-truthing
-9. **[Make a Shortlist](site_selection/08_Make_Shortlist)** - Final selection
+1. **[Site Selection Overview](/restoration-playbook/site_selection/00_Site_Selection_Overview)** - Strategic framework
+2. **[Identify Potential Locations](/restoration-playbook/site_selection/01_Identify_Potential_Locations)** - Geographic analysis
+3. **[Evaluate Land Condition](/restoration-playbook/site_selection/02_Evaluate_Land_Condition)** - Site assessment
+4. **[Estimate Restoration Potential](/restoration-playbook/site_selection/03_Estimate_Restoration_Potential)** - Feasibility analysis
+5. **[Consider Accessibility](/restoration-playbook/site_selection/04_Consider_Accessibility)** - Practical access
+6. **[Research Local Regulations](/restoration-playbook/site_selection/05_Research_Local_Regulations)** - Legal compliance
+7. **[Contact Landowners](/restoration-playbook/site_selection/06_Contact_Landowners)** - Relationship building
+8. **[Visit Sites](/restoration-playbook/site_selection/07_Visit_Sites)** - Ground-truthing
+9. **[Make a Shortlist](/restoration-playbook/site_selection/08_Make_Shortlist)** - Final selection
 
 ### Phase 2: Reforestation (7 Tasks)
 **Purpose:** Restore forest ecosystems through strategic tree planting
@@ -290,11 +290,11 @@ This template represents:
 
 **Choose Your Path:**
 
-**🌱 New Project:** Start with [Site Selection](site_selection/00_Site_Selection_Overview)
+**🌱 New Project:** Start with [Site Selection](/restoration-playbook/site_selection/00_Site_Selection_Overview)
 
 **🤝 Community Focus:** Begin with [Community Engagement](/restoration-playbook/community_engagement/00_Community_Engagement_Overview)
 
-**🌲 Ecological Priority:** Jump to [Reforestation](reforestation/00_Reforestation_Overview) or [Biodiversity](biodiversity/00_Biodiversity_Overview)
+**🌲 Ecological Priority:** Jump to [Reforestation](/restoration-playbook/reforestation/00_Reforestation_Overview) or [Biodiversity](/restoration-playbook/biodiversity/00_Biodiversity_Overview)
 
 **💧 Water Issues:** Focus on [Water Management](/restoration-playbook/water_management/00_Water_Management_Overview)
 


### PR DESCRIPTION
- Fix port number to 3023 in root README
- Fix documentation structure link path
- Fix Obsidian link syntax description
- Add GitHub repository and GitHub Pages links
- Fix all restoration playbook internal links to use full Docusaurus paths
- Update sync script command references
- Update documentation structure description to reflect strategic/ folder