### PR TITLE
Fix internal links and navigation throughout documentation

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -46,61 +46,61 @@ Create a **habitat for wildlife** and **restore land to become a shelter and san
 
 **What we need:** Support to find the right ways, ask the right questions, and organize properly. We need help exploring options, not prescriptive plans with concrete dates and costs.
 
-→ See Current Status for detailed assessment
+→ See [Current Status](/vision-strategy/current-status) for detailed assessment
 
 ---
 
 ## 📋 Quick Navigation
 
 ### Core Strategy
-- Executive Summary - Vision, mission, investment ask
-- Project Vision & Context - Global challenge, solution, geography
-- Success Factors & Assumptions - What makes or breaks this project
-- Current Status - Where we are, what's needed
+- [Executive Summary](/vision-strategy/executive-summary) - Vision, mission, investment ask
+- [Project Vision & Context](/vision-strategy/project-vision) - Global challenge, solution, geography
+- [Success Factors & Assumptions](/vision-strategy/success-factors) - What makes or breaks this project
+- [Current Status](/vision-strategy/current-status) - Where we are, what's needed
 
 ### Organization
-- Organizational Structure - Legal entity setup and structure
-- Governance Framework - Board, decision-making, accountability
-- Team & Roles - Staffing plan, roles, hiring timeline
-- Legal Framework - Regulatory compliance, permits
+- [Organizational Structure](/organization/organizational-structure) - Legal entity setup and structure
+- [Governance Framework](/organization/governance) - Board, decision-making, accountability
+- [Team & Roles](/organization/team-roles) - Staffing plan, roles, hiring timeline
+- [Legal Framework](/organization/legal-framework) - Regulatory compliance, permits
 
 ### Operations
-- Restoration Methodology - Location-adaptive restoration methods
-- Technology Integration - Solar, water, and monitoring systems
-- Restoration Challenges & Solutions - Common challenges and solutions
+- [Restoration Methodology](/operations/restoration-methodology) - Location-adaptive restoration methods
+- [Technology Integration](/operations/technology-integration) - Solar, water, and monitoring systems
+- [Restoration Challenges & Solutions](/operations/challenges-solutions) - Common challenges and solutions
 
 ### Business
-- Business Model - Revenue streams and financial sustainability
-- Financial Projections - Financial scenarios and projections
-- Funding Strategy - Bootstrap funding pathways and strategies
+- [Business Model](/business/business-model) - Revenue streams and financial sustainability
+- [Financial Projections](/business/financial-projections) - Financial scenarios and projections
+- [Funding Strategy](/business/funding-strategy) - Bootstrap funding pathways and strategies
 
 ### Growth
-- Expansion Strategy - Scaling approach and growth phases
-- Site Selection - Geographic options and land acquisition
-- Adaptive Timeline - Phased implementation approach
-- Operations Action Plan - Day-to-day operations guide
-- Tiny House Infrastructure - Off-grid living specifications
+- [Expansion Strategy](/growth/expansion-strategy) - Scaling approach and growth phases
+- [Site Selection](/growth/site-selection) - Geographic options and land acquisition
+- [Adaptive Timeline](/growth/adaptive-timeline) - Phased implementation approach
+- [Operations Action Plan](/growth/operations-action-plan) - Day-to-day operations guide
+- [Tiny House Infrastructure](/growth/tiny-house-infrastructure) - Off-grid living specifications
 
 ### Performance
-- Risk Assessment - Risk management and mitigation strategies
-- Key Performance Indicators - Metrics and success measurement
+- [Risk Assessment](/performance/risk-assessment) - Risk management and mitigation strategies
+- [Key Performance Indicators](/performance/kpis) - Metrics and success measurement
 
 ### Engagement
-- Marketing & Communications - Outreach and community engagement
+- [Marketing & Communications](/engagement/marketing-communications) - Outreach and community engagement
 
 ### Learning
-- Case Studies & Examples - Restoration project references
+- [Case Studies & Examples](/learning/case-studies) - Restoration project references
 
 ### Plans & Templates
-- Restoration Playbook - Complete project template for ecological restoration (44 tasks across 6 phases)
+- [Restoration Playbook](/restoration-playbook/README) - Complete project template for ecological restoration (44 tasks across 6 phases)
   - This is the **Plan** part of Vision → Plan → Reality
   - Template/playbook to customize for your specific project
   - When you start your actual project, copy this to your project folder
 
 ### Resources
-- Quick Reference Guide - How to use this documentation
-- Roadmap - Multi-year vision, phases, and current blockers
-- Feature Wishlist - Desired enhancements and future ideas
+- [Quick Reference Guide](/resources/quick-reference) - How to use this documentation
+- [Roadmap](/resources/roadmap) - Multi-year vision, phases, and current blockers
+- [Feature Wishlist](/resources/feature-wishlist) - Desired enhancements and future ideas
 
 ---
 

--- a/docs/restoration-playbook/README.md
+++ b/docs/restoration-playbook/README.md
@@ -94,70 +94,70 @@ This is a **comprehensive template and playbook** for ecological restoration pro
 ### Phase 1: Site Selection (9 Tasks)
 **Purpose:** Find and evaluate locations with highest restoration potential
 
-1. **[Site Selection Overview](/restoration-playbook/site_selection/00_Site_Selection_Overview)** - Strategic framework
-2. **[Identify Potential Locations](/restoration-playbook/site_selection/01_Identify_Potential_Locations)** - Geographic analysis
-3. **[Evaluate Land Condition](/restoration-playbook/site_selection/02_Evaluate_Land_Condition)** - Site assessment
-4. **[Estimate Restoration Potential](/restoration-playbook/site_selection/03_Estimate_Restoration_Potential)** - Feasibility analysis
-5. **[Consider Accessibility](/restoration-playbook/site_selection/04_Consider_Accessibility)** - Practical access
-6. **[Research Local Regulations](/restoration-playbook/site_selection/05_Research_Local_Regulations)** - Legal compliance
-7. **[Contact Landowners](/restoration-playbook/site_selection/06_Contact_Landowners)** - Relationship building
-8. **[Visit Sites](/restoration-playbook/site_selection/07_Visit_Sites)** - Ground-truthing
-9. **[Make a Shortlist](/restoration-playbook/site_selection/08_Make_Shortlist)** - Final selection
+1. **[Site Selection Overview](/restoration-playbook/site_selection/restoration-playbook-site_selection-00_Site_Selection_Overview)** - Strategic framework
+2. **[Identify Potential Locations](/restoration-playbook/site_selection/restoration-playbook-site_selection-01_Identify_Potential_Locations)** - Geographic analysis
+3. **[Evaluate Land Condition](/restoration-playbook/site_selection/restoration-playbook-site_selection-02_Evaluate_Land_Condition)** - Site assessment
+4. **[Estimate Restoration Potential](/restoration-playbook/site_selection/restoration-playbook-site_selection-03_Estimate_Restoration_Potential)** - Feasibility analysis
+5. **[Consider Accessibility](/restoration-playbook/site_selection/restoration-playbook-site_selection-04_Consider_Accessibility)** - Practical access
+6. **[Research Local Regulations](/restoration-playbook/site_selection/restoration-playbook-site_selection-05_Research_Local_Regulations)** - Legal compliance
+7. **[Contact Landowners](/restoration-playbook/site_selection/restoration-playbook-site_selection-06_Contact_Landowners)** - Relationship building
+8. **[Visit Sites](/restoration-playbook/site_selection/restoration-playbook-site_selection-07_Visit_Sites)** - Ground-truthing
+9. **[Make a Shortlist](/restoration-playbook/site_selection/restoration-playbook-site_selection-08_Make_Shortlist)** - Final selection
 
 ### Phase 2: Reforestation (7 Tasks)
 **Purpose:** Restore forest ecosystems through strategic tree planting
 
-1. **[Reforestation Overview](/restoration-playbook/reforestation/00_Reforestation_Overview)** - Forest restoration framework
-2. **[Identify Native Species](/restoration-playbook/reforestation/01_Identify_Native_Species)** - Species selection
-3. **[Source Seedlings](/restoration-playbook/reforestation/02_Source_Seedlings)** - Procurement strategies
-4. **[Prepare Land](/restoration-playbook/reforestation/03_Prepare_Land)** - Site preparation
-5. **[Plant Seedlings](/restoration-playbook/reforestation/04_Plant_Seedlings)** - Planting techniques
-6. **[Monitor Growth](/restoration-playbook/reforestation/05_Monitor_Growth)** - Progress tracking
-7. **[Long-Term Management](/restoration-playbook/reforestation/06_Long_Term_Management)** - Ongoing stewardship
+1. **[Reforestation Overview](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)** - Forest restoration framework
+2. **[Identify Native Species](/restoration-playbook/reforestation/restoration-playbook-reforestation-01_Identify_Native_Species)** - Species selection
+3. **[Source Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-02_Source_Seedlings)** - Procurement strategies
+4. **[Prepare Land](/restoration-playbook/reforestation/restoration-playbook-reforestation-03_Prepare_Land)** - Site preparation
+5. **[Plant Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-04_Plant_Seedlings)** - Planting techniques
+6. **[Monitor Growth](/restoration-playbook/reforestation/restoration-playbook-reforestation-05_Monitor_Growth)** - Progress tracking
+7. **[Long-Term Management](/restoration-playbook/reforestation/restoration-playbook-reforestation-06_Long_Term_Management)** - Ongoing stewardship
 
 ### Phase 3: Biodiversity Conservation (7 Tasks)
 **Purpose:** Protect and enhance native species and ecological communities
 
-1. **[Biodiversity Overview](/restoration-playbook/biodiversity/00_Biodiversity_Overview)** - Conservation strategy
-2. **[Assess Biodiversity](/restoration-playbook/biodiversity/01_Assess_Biodiversity)** - Baseline surveys
-3. **[Restore Habitats](/restoration-playbook/biodiversity/02_Restore_Habitats)** - Habitat creation
-4. **[Create Protected Areas](/restoration-playbook/biodiversity/03_Create_Protected_Areas)** - Sanctuary establishment
-5. **[Manage Invasive Species](/restoration-playbook/biodiversity/04_Manage_Invasive_Species)** - Control strategies
-6. **[Reintroduce Lost Species](/restoration-playbook/biodiversity/05_Reintroduce_Lost_Species)** - Species recovery
-7. **[Monitor Biodiversity](/restoration-playbook/biodiversity/06_Monitor_Biodiversity)** - Long-term tracking
+1. **[Biodiversity Overview](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)** - Conservation strategy
+2. **[Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)** - Baseline surveys
+3. **[Restore Habitats](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-02_Restore_Habitats)** - Habitat creation
+4. **[Create Protected Areas](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-03_Create_Protected_Areas)** - Sanctuary establishment
+5. **[Manage Invasive Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-04_Manage_Invasive_Species)** - Control strategies
+6. **[Reintroduce Lost Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-05_Reintroduce_Lost_Species)** - Species recovery
+7. **[Monitor Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-06_Monitor_Biodiversity)** - Long-term tracking
 
 ### Phase 4: Soil Restoration (7 Tasks)
 **Purpose:** Rebuild soil health as foundation for ecosystem recovery
 
-1. **[Soil Restoration Overview](/restoration-playbook/soil_restoration/00_Soil_Restoration_Overview)** - Soil health framework
-2. **[Assess Soil Health](/restoration-playbook/soil_restoration/01_Assess_Soil_Health)** - Testing and analysis
-3. **[Add Organic Matter](/restoration-playbook/soil_restoration/02_Add_Organic_Matter)** - Soil amendments
-4. **[Reduce Tillage](/restoration-playbook/soil_restoration/03_Reduce_Tillage)** - Conservation practices
-5. **[Rotate Crops](/restoration-playbook/soil_restoration/04_Rotate_Crops)** - Diversification strategies
-6. **[Manage Pests & Diseases](/restoration-playbook/soil_restoration/05_Manage_Pests_Diseases)** - Integrated management
-7. **[Monitor Soil Health](/restoration-playbook/soil_restoration/06_Monitor_Soil_Health)** - Progress tracking
+1. **[Soil Restoration Overview](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)** - Soil health framework
+2. **[Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)** - Testing and analysis
+3. **[Add Organic Matter](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-02_Add_Organic_Matter)** - Soil amendments
+4. **[Reduce Tillage](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-03_Reduce_Tillage)** - Conservation practices
+5. **[Rotate Crops](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-04_Rotate_Crops)** - Diversification strategies
+6. **[Manage Pests & Diseases](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-05_Manage_Pests_Diseases)** - Integrated management
+7. **[Monitor Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-06_Monitor_Soil_Health)** - Progress tracking
 
 ### Phase 5: Water Management (7 Tasks)
 **Purpose:** Ensure sustainable water use supporting ecosystem and community
 
-1. **[Water Management Overview](/restoration-playbook/water_management/00_Water_Management_Overview)** - Water strategy
-2. **[Assess Water Needs](/restoration-playbook/water_management/01_Assess_Water_Needs)** - Demand analysis
-3. **[Rainwater Harvesting](/restoration-playbook/water_management/02_Rainwater_Harvesting)** - Capture systems
-4. **[Build Water Storage Structures](/restoration-playbook/water_management/03_Build_Water_Storage_Structures)** - Infrastructure
-5. **[Efficient Irrigation](/restoration-playbook/water_management/04_Efficient_Irrigation)** - Conservation techniques
-6. **[Drought Management](/restoration-playbook/water_management/05_Drought_Management)** - Resilience planning
-7. **[Monitor Water Use](/restoration-playbook/water_management/06_Monitor_Water_Use)** - Usage tracking
+1. **[Water Management Overview](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)** - Water strategy
+2. **[Assess Water Needs](/restoration-playbook/water_management/restoration-playbook-water_management-01_Assess_Water_Needs)** - Demand analysis
+3. **[Rainwater Harvesting](/restoration-playbook/water_management/restoration-playbook-water_management-02_Rainwater_Harvesting)** - Capture systems
+4. **[Build Water Storage Structures](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)** - Infrastructure
+5. **[Efficient Irrigation](/restoration-playbook/water_management/restoration-playbook-water_management-04_Efficient_Irrigation)** - Conservation techniques
+6. **[Drought Management](/restoration-playbook/water_management/restoration-playbook-water_management-05_Drought_Management)** - Resilience planning
+7. **[Monitor Water Use](/restoration-playbook/water_management/restoration-playbook-water_management-06_Monitor_Water_Use)** - Usage tracking
 
 ### Phase 6: Community Engagement (7 Tasks)
 **Purpose:** Build lasting partnerships ensuring long-term stewardship
 
-1. **[Community Engagement Overview](/restoration-playbook/community_engagement/00_Community_Engagement_Overview)** - Engagement strategy
-2. **[Identify Stakeholders](/restoration-playbook/community_engagement/01_Identify_Stakeholders)** - Stakeholder mapping
-3. **[Communicate Plans](/restoration-playbook/community_engagement/02_Communicate_Plans)** - Outreach and dialogue
-4. **[Educate Community](/restoration-playbook/community_engagement/03_Educate_Community)** - Environmental education
-5. **[Involve Community](/restoration-playbook/community_engagement/04_Involve_Community)** - Active participation
-6. **[Share Benefits](/restoration-playbook/community_engagement/05_Share_Benefits)** - Equitable distribution
-7. **[Maintain Communication](/restoration-playbook/community_engagement/06_Maintain_Communication)** - Long-term relationships
+1. **[Community Engagement Overview](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)** - Engagement strategy
+2. **[Identify Stakeholders](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-01_Identify_Stakeholders)** - Stakeholder mapping
+3. **[Communicate Plans](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-02_Communicate_Plans)** - Outreach and dialogue
+4. **[Educate Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-03_Educate_Community)** - Environmental education
+5. **[Involve Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-04_Involve_Community)** - Active participation
+6. **[Share Benefits](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-05_Share_Benefits)** - Equitable distribution
+7. **[Maintain Communication](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-06_Maintain_Communication)** - Long-term relationships
 
 ---
 
@@ -290,15 +290,15 @@ This template represents:
 
 **Choose Your Path:**
 
-**🌱 New Project:** Start with [Site Selection](/restoration-playbook/site_selection/00_Site_Selection_Overview)
+**🌱 New Project:** Start with [Site Selection](/restoration-playbook/site_selection/restoration-playbook-site_selection-00_Site_Selection_Overview)
 
-**🤝 Community Focus:** Begin with [Community Engagement](/restoration-playbook/community_engagement/00_Community_Engagement_Overview)
+**🤝 Community Focus:** Begin with [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
-**🌲 Ecological Priority:** Jump to [Reforestation](/restoration-playbook/reforestation/00_Reforestation_Overview) or [Biodiversity](/restoration-playbook/biodiversity/00_Biodiversity_Overview)
+**🌲 Ecological Priority:** Jump to [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview) or [Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
 
-**💧 Water Issues:** Focus on [Water Management](/restoration-playbook/water_management/00_Water_Management_Overview)
+**💧 Water Issues:** Focus on [Water Management](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)
 
-**🌾 Soil Health:** Start with [Soil Restoration](/restoration-playbook/soil_restoration/00_Soil_Restoration_Overview)
+**🌾 Soil Health:** Start with [Soil Restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)
 
 **📚 Complete Overview:** Explore each phase systematically
 

--- a/docs/restoration-playbook/biodiversity/00_Biodiversity_Overview.md
+++ b/docs/restoration-playbook/biodiversity/00_Biodiversity_Overview.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 **Type:** Template/Playbook for Small Plot Restoration  
 **Status:** Template - Customize for Your Project
 
-[]( )| [Project Hub](../../00_Eco_Balance_Hub)
+[]( )| [Project Hub](/)
 
 ---
 
@@ -109,7 +109,7 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ### Phase 1: Assessment & Planning (Months 1-3)
 
-1. **[Assess Biodiversity](../../01_Assess_Biodiversity)**
+1. **[Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)**
    - Baseline species inventory
    - Habitat mapping
    - Identify key species and threats
@@ -117,13 +117,13 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ### Phase 2: Habitat Creation (Months 3-12)
 
-2. **[Restore Habitats](../../02_Restore_Habitats)**
+2. **[Restore Habitats](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-02_Restore_Habitats)**
    - Create diverse microhabitats
    - Restore damaged areas
    - Enhance existing habitats
    - *Duration: 6-12 months*
 
-3. **[Create Protected Areas](../../03_Create_Protected_Areas)**
+3. **[Create Protected Areas](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-03_Create_Protected_Areas)**
    - Designate sensitive zones
    - Minimize human disturbance
    - Establish management protocols
@@ -131,19 +131,19 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ### Phase 3: Active Management (Ongoing)
 
-4. **[Manage Invasive Species](../../04_Manage_Invasive_Species)**
+4. **[Manage Invasive Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-04_Manage_Invasive_Species)**
    - Identify and remove invasives
    - Prevent new introductions
    - Monitor for re-establishment
    - *Frequency: Monthly to quarterly checks*
 
-5. **[Reintroduce Lost Species](../../05_Reintroduce_Lost_Species)** *(Long-term)*
+5. **[Reintroduce Lost Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-05_Reintroduce_Lost_Species)** *(Long-term)*
    - Research historical species
    - Plan reintroduction programs
    - Partner with conservation organizations
    - *Timeline: Years 3-5+*
 
-6. **[Monitor Biodiversity](../../06_Monitor_Biodiversity)**
+6. **[Monitor Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-06_Monitor_Biodiversity)**
    - Regular surveys and observations
    - Track population trends
    - Document ecosystem changes
@@ -153,13 +153,13 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 🔗 Integration with Other Phases
 
-**Reforestation:** Trees create habitat → [Reforestation](../reforestation/00_Reforestation_Overview)
+**Reforestation:** Trees create habitat → [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)
 
-**Soil Health:** Soil biodiversity supports above-ground life → [Soil Restoration](../soil_restoration/00_Soil_Restoration_Overview)
+**Soil Health:** Soil biodiversity supports above-ground life → [Soil Restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)
 
-**Water:** Wetlands and ponds support aquatic biodiversity → [Water Management](../water_management/00_Water_Management_Overview)
+**Water:** Wetlands and ponds support aquatic biodiversity → [Water Management](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)
 
-**Community:** Local knowledge and participation → [Community Engagement](../community_engagement/00_Community_Engagement_Overview)
+**Community:** Local knowledge and participation → [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
 ---
 
@@ -197,12 +197,12 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 📚 Task Files
 
-1. [Assess Biodiversity](../../01_Assess_Biodiversity)
-2. [Restore Habitats](../../02_Restore_Habitats)
-3. [Create Protected Areas](../../03_Create_Protected_Areas)
-4. [Manage Invasive Species](../../04_Manage_Invasive_Species)
-5. [Reintroduce Lost Species](../../05_Reintroduce_Lost_Species)
-6. [Monitor Biodiversity](../../06_Monitor_Biodiversity)
+1. [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
+2. [Restore Habitats](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-02_Restore_Habitats)
+3. [Create Protected Areas](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-03_Create_Protected_Areas)
+4. [Manage Invasive Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-04_Manage_Invasive_Species)
+5. [Reintroduce Lost Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-05_Reintroduce_Lost_Species)
+6. [Monitor Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-06_Monitor_Biodiversity)
 
 ---
 

--- a/docs/restoration-playbook/biodiversity/01_Assess_Biodiversity.md
+++ b/docs/restoration-playbook/biodiversity/01_Assess_Biodiversity.md
@@ -326,7 +326,7 @@ These must be done - they are based on scientific consensus:
 ## Next Steps
 
 Once baseline is established:
-→ [Task 2: Restore Habitats](../../02_Restore_Habitats)
+→ [Task 2: Restore Habitats](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-02_Restore_Habitats)
 
 ---
 

--- a/docs/restoration-playbook/biodiversity/02_Restore_Habitats.md
+++ b/docs/restoration-playbook/biodiversity/02_Restore_Habitats.md
@@ -144,7 +144,7 @@ These must be followed - they are based on scientific consensus:
 - Determine which can be restored vs. created new
 
 **Target Species Needs:**
-- Based on biodiversity assessment → [Assess Biodiversity](../../01_Assess_Biodiversity)
+- Based on biodiversity assessment → [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
 - What habitats do priority species require?
 - Which life stages need which habitats? (breeding, feeding, shelter)
 - Are specialist species dependent on specific habitats?
@@ -165,7 +165,7 @@ Create multi-layered vegetation structure:
 - Mature trees providing cover and food
 - Mix of species with different characteristics
 - Consider deciduous vs. evergreen balance
-- Plan for 15-30 year maturity → [Reforestation](../reforestation/00_Reforestation_Overview)
+- Plan for 15-30 year maturity → [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)
 
 **Mid-Story Layer:**
 - Smaller trees and tall shrubs (2-8m height)
@@ -216,7 +216,7 @@ Create varied spatial patterns:
 ### Step 3: Native Vegetation Restoration
 
 **Species Selection:**
-- Use only native species → [Identify Native Species](../reforestation/01_Identify_Native_Species)
+- Use only native species → [Identify Native Species](/restoration-playbook/reforestation/restoration-playbook-reforestation-01_Identify_Native_Species)
 - Match species to microhabitats and conditions
 - Include diversity of growth forms
 - Prioritize wildlife value (food, shelter)
@@ -235,8 +235,8 @@ Create varied spatial patterns:
 - Consider mature spacing requirements
 
 **Establishment:**
-- Site preparation → [Prepare Land](../reforestation/03_Prepare_Land)
-- Planting techniques → [Plant Seedlings](../reforestation/04_Plant_Seedlings)
+- Site preparation → [Prepare Land](/restoration-playbook/reforestation/restoration-playbook-reforestation-03_Prepare_Land)
+- Planting techniques → [Plant Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-04_Plant_Seedlings)
 - Protection from herbivores (fencing, guards)
 - Watering and maintenance
 - Weed/invasive control
@@ -246,10 +246,10 @@ Create varied spatial patterns:
 Healthy habitats require healthy soil:
 
 **Soil Health:**
-- Restore soil organic matter → [Add Organic Matter](../soil_restoration/02_Add_Organic_Matter)
+- Restore soil organic matter → [Add Organic Matter](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-02_Add_Organic_Matter)
 - Improve soil structure and drainage
 - Enhance microbial communities
-- Reduce compaction → [Reduce Tillage](../soil_restoration/03_Reduce_Tillage)
+- Reduce compaction → [Reduce Tillage](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-03_Reduce_Tillage)
 
 **Soil Fauna:**
 - Encourage earthworms
@@ -268,7 +268,7 @@ Water is critical for biodiversity:
 - Enhance riparian zones
 
 **Created Water Features:**
-- Seasonal ponds for amphibians → [Water Storage](../water_management/03_Build_Water_Storage_Structures)
+- Seasonal ponds for amphibians → [Water Storage](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)
 - Seeps and springs
 - Drinking areas for mammals
 - Birdbaths and shallow pools
@@ -383,7 +383,7 @@ Water is critical for biodiversity:
 ## Next Steps
 
 Once habitats are restored:
-→ [Task 3: Create Protected Areas](../../03_Create_Protected_Areas)
+→ [Task 3: Create Protected Areas](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-03_Create_Protected_Areas)
 
 ---
 

--- a/docs/restoration-playbook/biodiversity/03_Create_Protected_Areas.md
+++ b/docs/restoration-playbook/biodiversity/03_Create_Protected_Areas.md
@@ -138,7 +138,7 @@ These must be followed - they are based on scientific consensus:
 - Wetlands, riparian zones, springs
 - Old-growth or mature forest patches
 - Rare habitat types
-- Species-rich areas identified in assessment → [Assess Biodiversity](../../01_Assess_Biodiversity)
+- Species-rich areas identified in assessment → [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
 
 **Critical Wildlife Areas:**
 - Nesting sites (birds, mammals)
@@ -296,7 +296,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once protected areas are established:
-→ [Task 4: Manage Invasive Species](../../04_Manage_Invasive_Species)
+→ [Task 4: Manage Invasive Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-04_Manage_Invasive_Species)
 
 ---
 

--- a/docs/restoration-playbook/biodiversity/04_Manage_Invasive_Species.md
+++ b/docs/restoration-playbook/biodiversity/04_Manage_Invasive_Species.md
@@ -136,7 +136,7 @@ These must be followed - they are based on scientific and ethical consensus:
 ### Step 1: Identify Invasive Species
 
 **Comprehensive Survey:**
-- Conduct thorough site assessment → [Assess Biodiversity](../../01_Assess_Biodiversity)
+- Conduct thorough site assessment → [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
 - Identify all non-native species present
 - Document distribution and abundance
 - Map invasive species locations with GPS
@@ -630,18 +630,18 @@ Use multiple methods in combination:
 ## 📊 Related Documents
 
 **Biodiversity Conservation:**
-- [Biodiversity Overview](../../00_Biodiversity_Overview)
-- [Previous: Create Protected Areas](../../03_Create_Protected_Areas)
-- [Next: Reintroduce Lost Species](../../05_Reintroduce_Lost_Species)
+- [Biodiversity Overview](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
+- [Previous: Create Protected Areas](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-03_Create_Protected_Areas)
+- [Next: Reintroduce Lost Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-05_Reintroduce_Lost_Species)
 
 **Related Tasks:**
-- [Assess Biodiversity](../../01_Assess_Biodiversity)
-- [Restore Habitats](../../02_Restore_Habitats)
-- [Monitor Biodiversity](../../06_Monitor_Biodiversity)
+- [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
+- [Restore Habitats](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-02_Restore_Habitats)
+- [Monitor Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-06_Monitor_Biodiversity)
 
 **Strategic Context:**
-- [Restoration Methodology](../../20_Restoration_Methodology)
-- [Restoration Challenges](../../22_Restoration_Challenges_Solutions)
+- [Restoration Methodology](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-20_Restoration_Methodology)
+- [Restoration Challenges](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-22_Restoration_Challenges_Solutions)
 
 ---
 
@@ -703,4 +703,4 @@ Use multiple methods in combination:
 ---
 
 *Part of the [Implementation Tasks](README) series*  
-*Next: [Reintroduce Lost Species](../../05_Reintroduce_Lost_Species)*
+*Next: [Reintroduce Lost Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-05_Reintroduce_Lost_Species)*

--- a/docs/restoration-playbook/biodiversity/05_Reintroduce_Lost_Species.md
+++ b/docs/restoration-playbook/biodiversity/05_Reintroduce_Lost_Species.md
@@ -299,7 +299,7 @@ These must be followed - they are based on scientific and ethical consensus:
 ## Next Steps
 
 Once species are reintroduced:
-→ [Task 6: Monitor Biodiversity](../../06_Monitor_Biodiversity)
+→ [Task 6: Monitor Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-06_Monitor_Biodiversity)
 
 ---
 

--- a/docs/restoration-playbook/biodiversity/06_Monitor_Biodiversity.md
+++ b/docs/restoration-playbook/biodiversity/06_Monitor_Biodiversity.md
@@ -152,7 +152,7 @@ These must be followed - they are based on scientific consensus:
 - Trophic structure (predators, prey, plants)
 
 **Establish Baselines:**
-- Conduct initial comprehensive assessment → [Assess Biodiversity](../../01_Assess_Biodiversity)
+- Conduct initial comprehensive assessment → [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
 - Document starting conditions
 - Set measurable targets
 - Define success criteria

--- a/docs/restoration-playbook/community_engagement/00_Community_Engagement_Overview.md
+++ b/docs/restoration-playbook/community_engagement/00_Community_Engagement_Overview.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 **Type:** Template/Playbook for Small Plot Restoration  
 **Status:** Template - Customize for Your Project
 
-[]( )| [Project Hub](../../00_Eco_Balance_Hub)
+[]( )| [Project Hub](/)
 
 ---
 
@@ -131,18 +131,18 @@ These are the constraints based on scientific consensus that cannot be compromis
 ## 📋 Implementation Process
 
 ### Phase 1: Stakeholder Identification (Weeks 1-2)
-1. **[Identify Stakeholders](../../01_Identify_Stakeholders)** - Map all relevant stakeholders and understand community context
+1. **[Identify Stakeholders](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-01_Identify_Stakeholders)** - Map all relevant stakeholders and understand community context
 
 ### Phase 2: Communication & Education (Weeks 3-12)
-2. **[Communicate Plans](../../02_Communicate_Plans)** - Share project vision and seek community input
-3. **[Educate Community](../../03_Educate_Community)** - Build understanding of restoration principles and benefits
+2. **[Communicate Plans](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-02_Communicate_Plans)** - Share project vision and seek community input
+3. **[Educate Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-03_Educate_Community)** - Build understanding of restoration principles and benefits
 
 ### Phase 3: Active Involvement (Implementation Period)
-4. **[Involve Community](../../04_Involve_Community)** - Engage community in restoration activities
+4. **[Involve Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-04_Involve_Community)** - Engage community in restoration activities
 
 ### Phase 4: Benefit Sharing & Maintenance (Ongoing)
-5. **[Share Benefits](../../05_Share_Benefits)** - Ensure community receives benefits from restoration
-6. **[Maintain Communication](../../06_Maintain_Communication)** - Keep relationships and communication ongoing
+5. **[Share Benefits](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-05_Share_Benefits)** - Ensure community receives benefits from restoration
+6. **[Maintain Communication](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-06_Maintain_Communication)** - Keep relationships and communication ongoing
 
 ---
 
@@ -204,15 +204,15 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 **All Phases:** Community engagement supports and enhances all restoration activities
 
-**Site Selection:** Community input shapes site selection → [Site Selection](../site_selection/00_Site_Selection_Overview)
+**Site Selection:** Community input shapes site selection → [Site Selection](/restoration-playbook/site_selection/restoration-playbook-site_selection-00_Site_Selection_Overview)
 
-**Reforestation:** Community involvement in planting activities → [Reforestation](../reforestation/00_Reforestation_Overview)
+**Reforestation:** Community involvement in planting activities → [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)
 
-**Biodiversity:** Local knowledge improves species selection → [Biodiversity Conservation](../biodiversity/00_Biodiversity_Overview)
+**Biodiversity:** Local knowledge improves species selection → [Biodiversity Conservation](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
 
-**Soil Restoration:** Community work days for soil improvement → [Soil Restoration](../soil_restoration/00_Soil_Restoration_Overview)
+**Soil Restoration:** Community work days for soil improvement → [Soil Restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)
 
-**Water Management:** Community input on water priorities → [Water Management](../water_management/00_Water_Management_Overview)
+**Water Management:** Community input on water priorities → [Water Management](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)
 
 ---
 
@@ -238,12 +238,12 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 📚 Task Files
 
-1. [Identify Stakeholders](../../01_Identify_Stakeholders)
-2. [Communicate Plans](../../02_Communicate_Plans)
-3. [Educate Community](../../03_Educate_Community)
-4. [Involve Community](../../04_Involve_Community)
-5. [Share Benefits](../../05_Share_Benefits)
-6. [Maintain Communication](../../06_Maintain_Communication)
+1. [Identify Stakeholders](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-01_Identify_Stakeholders)
+2. [Communicate Plans](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-02_Communicate_Plans)
+3. [Educate Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-03_Educate_Community)
+4. [Involve Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-04_Involve_Community)
+5. [Share Benefits](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-05_Share_Benefits)
+6. [Maintain Communication](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-06_Maintain_Communication)
 
 ---
 

--- a/docs/restoration-playbook/community_engagement/01_Identify_Stakeholders.md
+++ b/docs/restoration-playbook/community_engagement/01_Identify_Stakeholders.md
@@ -257,7 +257,7 @@ These must be followed - they are based on scientific and ethical consensus:
 ## Next Steps
 
 Once stakeholders are identified:
-→ [Task 2: Communicate Plans](../../02_Communicate_Plans)
+→ [Task 2: Communicate Plans](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-02_Communicate_Plans)
 
 ---
 

--- a/docs/restoration-playbook/community_engagement/02_Communicate_Plans.md
+++ b/docs/restoration-playbook/community_engagement/02_Communicate_Plans.md
@@ -395,7 +395,7 @@ These must be followed - they are based on scientific and ethical consensus:
 ## Next Steps
 
 Once plans are communicated:
-→ [Task 3: Educate Community](../../03_Educate_Community)
+→ [Task 3: Educate Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-03_Educate_Community)
 
 ---
 

--- a/docs/restoration-playbook/community_engagement/03_Educate_Community.md
+++ b/docs/restoration-playbook/community_engagement/03_Educate_Community.md
@@ -368,7 +368,7 @@ These must be followed - they are based on scientific and ethical consensus:
 ## Next Steps
 
 Once community education is established:
-→ [Task 4: Involve Community](../../04_Involve_Community)
+→ [Task 4: Involve Community](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-04_Involve_Community)
 
 ---
 

--- a/docs/restoration-playbook/community_engagement/04_Involve_Community.md
+++ b/docs/restoration-playbook/community_engagement/04_Involve_Community.md
@@ -466,7 +466,7 @@ These must be followed - they are based on scientific and ethical consensus:
 ## Next Steps
 
 Once community is involved:
-→ [Task 5: Share Benefits](../../05_Share_Benefits)
+→ [Task 5: Share Benefits](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-05_Share_Benefits)
 
 ---
 

--- a/docs/restoration-playbook/community_engagement/05_Share_Benefits.md
+++ b/docs/restoration-playbook/community_engagement/05_Share_Benefits.md
@@ -321,7 +321,7 @@ These must be followed - they are based on ethical and practical consensus:
 ## Next Steps
 
 Once benefits are shared:
-→ [Task 6: Maintain Communication](../../06_Maintain_Communication)
+→ [Task 6: Maintain Communication](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-06_Maintain_Communication)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/00_Reforestation_Overview.md
+++ b/docs/restoration-playbook/reforestation/00_Reforestation_Overview.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 **Type:** Template/Playbook for Small Plot Restoration  
 **Status:** Template - Customize for Your Project
 
-[]( )| [Project Hub](../../00_Eco_Balance_Hub)
+[]( )| [Project Hub](/)
 
 ---
 
@@ -137,19 +137,19 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ### Phase 1: Planning & Preparation (Months 1-3)
 
-1. **[Identify Native Species](../../01_Identify_Native_Species)**
+1. **[Identify Native Species](/restoration-playbook/reforestation/restoration-playbook-reforestation-01_Identify_Native_Species)**
    - Research native trees and shrubs
    - Consult botanists and ecologists
    - Consider climate adaptation and ecosystem roles
    - *Duration: 2-4 weeks*
 
-2. **[Source Seedlings](../../02_Source_Seedlings)**
+2. **[Source Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-02_Source_Seedlings)**
    - Find reputable nurseries or suppliers
    - Ensure health and disease-free stock
    - Plan timing for optimal planting season
    - *Duration: 4-6 weeks (including lead time)*
 
-3. **[Prepare the Land](../../03_Prepare_Land)**
+3. **[Prepare the Land](/restoration-playbook/reforestation/restoration-playbook-reforestation-03_Prepare_Land)**
    - Clear debris and assess soil conditions
    - Plan planting layout and spacing
    - Improve soil fertility if needed
@@ -157,7 +157,7 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ### Phase 2: Implementation (Months 3-4)
 
-4. **[Plant Seedlings](../../04_Plant_Seedlings)**
+4. **[Plant Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-04_Plant_Seedlings)**
    - Follow proper planting techniques
    - Ensure adequate spacing and depth
    - Water thoroughly after planting
@@ -165,13 +165,13 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ### Phase 3: Monitoring & Management (Ongoing)
 
-5. **[Monitor Growth](../../05_Monitor_Growth)**
+5. **[Monitor Growth](/restoration-playbook/reforestation/restoration-playbook-reforestation-05_Monitor_Growth)**
    - Regular site visits and health checks
    - Track survival rates and growth metrics
    - Replace dead or diseased trees promptly
    - *Frequency: Monthly (Year 1), Quarterly thereafter*
 
-6. **[Long-Term Management](../../06_Long_Term_Management)**
+6. **[Long-Term Management](/restoration-playbook/reforestation/restoration-playbook-reforestation-06_Long_Term_Management)**
    - Pruning and thinning as needed
    - Pest, disease, and fire protection
    - Adaptive management based on results
@@ -181,15 +181,15 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 🔗 Integration with Other Phases
 
-**Site Selection:** Site characteristics determine tree species and methods → [Site Selection](../site_selection/00_Site_Selection_Overview)
+**Site Selection:** Site characteristics determine tree species and methods → [Site Selection](/restoration-playbook/site_selection/restoration-playbook-site_selection-00_Site_Selection_Overview)
 
-**Soil Health:** Healthy soil is essential for tree survival → [Soil Restoration](../soil_restoration/00_Soil_Restoration_Overview)
+**Soil Health:** Healthy soil is essential for tree survival → [Soil Restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)
 
-**Water Management:** Adequate water during establishment → [Water Management](../water_management/00_Water_Management_Overview)
+**Water Management:** Adequate water during establishment → [Water Management](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)
 
-**Biodiversity:** Trees create habitat for wildlife → [Biodiversity Conservation](../biodiversity/00_Biodiversity_Overview)
+**Biodiversity:** Trees create habitat for wildlife → [Biodiversity Conservation](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
 
-**Community Engagement:** Local participation in planting activities → [Community Engagement](../community_engagement/00_Community_Engagement_Overview)
+**Community Engagement:** Local participation in planting activities → [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
 ---
 
@@ -215,12 +215,12 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 📚 Task Files
 
-1. [Identify Native Species](../../01_Identify_Native_Species)
-2. [Source Seedlings](../../02_Source_Seedlings)
-3. [Prepare Land](../../03_Prepare_Land)
-4. [Plant Seedlings](../../04_Plant_Seedlings)
-5. [Monitor Growth](../../05_Monitor_Growth)
-6. [Long-Term Management](../../06_Long_Term_Management)
+1. [Identify Native Species](/restoration-playbook/reforestation/restoration-playbook-reforestation-01_Identify_Native_Species)
+2. [Source Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-02_Source_Seedlings)
+3. [Prepare Land](/restoration-playbook/reforestation/restoration-playbook-reforestation-03_Prepare_Land)
+4. [Plant Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-04_Plant_Seedlings)
+5. [Monitor Growth](/restoration-playbook/reforestation/restoration-playbook-reforestation-05_Monitor_Growth)
+6. [Long-Term Management](/restoration-playbook/reforestation/restoration-playbook-reforestation-06_Long_Term_Management)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/01_Identify_Native_Species.md
+++ b/docs/restoration-playbook/reforestation/01_Identify_Native_Species.md
@@ -137,7 +137,7 @@ These must be followed - they are based on scientific consensus:
 - Organic matter content
 - Existing vegetation indicators
 
-→ Reference: [Assess Soil Health](../soil_restoration/01_Assess_Soil_Health)
+→ Reference: [Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)
 
 ### Step 3: Evaluate Species Suitability
 
@@ -210,7 +210,7 @@ These must be followed - they are based on scientific consensus:
 
 2. **Climate Adaptation:** Select species adapted to your climate (consider climate change projections)
 
-3. **Site Conditions:** Match species to your actual soil, water, and light conditions
+3. **Site Conditions:** Match species to your actual [soil](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview), [water](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview), and light conditions
 
 4. **Ecosystem Type:** Choose species appropriate for your target ecosystem (forest, woodland, savanna, etc.)
 
@@ -225,7 +225,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once species are identified:
-→ [Task 2: Source Seedlings](../../02_Source_Seedlings)
+→ [Task 2: Source Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-02_Source_Seedlings)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/02_Source_Seedlings.md
+++ b/docs/restoration-playbook/reforestation/02_Source_Seedlings.md
@@ -315,7 +315,7 @@ Apply your species mix percentages to determine quantities for each species.
 ## Next Steps
 
 Once seedlings are sourced:
-→ [Task 3: Prepare Land](../../03_Prepare_Land)
+→ [Task 3: Prepare Land](/restoration-playbook/reforestation/restoration-playbook-reforestation-03_Prepare_Land)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/03_Prepare_Land.md
+++ b/docs/restoration-playbook/reforestation/03_Prepare_Land.md
@@ -154,7 +154,7 @@ These must be followed - they are based on scientific consensus:
 - Check for compaction
 - Test drainage rate
 
-→ For soil details: [Assess Soil Health](../soil_restoration/01_Assess_Soil_Health)
+→ For soil details: [Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)
 
 ### Step 2: Clear Unwanted Vegetation
 
@@ -167,7 +167,7 @@ These must be followed - they are based on scientific consensus:
 - May require multiple treatments
 - Document species removed for monitoring
 
-→ Details: [Manage Invasive Species](../biodiversity/04_Manage_Invasive_Species)
+→ Details: [Manage Invasive Species](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-04_Manage_Invasive_Species)
 
 **Native Vegetation:**
 - **Preserve** existing native plants and trees
@@ -199,7 +199,7 @@ These must be followed - they are based on scientific consensus:
 - Enhance water retention
 - Support beneficial soil organisms
 
-→ Details: [Add Organic Matter](../soil_restoration/02_Add_Organic_Matter)
+→ Details: [Add Organic Matter](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-02_Add_Organic_Matter)
 
 **Address Compaction:**
 - Break up compacted layers if severe
@@ -267,7 +267,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once land is prepared:
-→ [Task 4: Plant Seedlings](../../04_Plant_Seedlings)
+→ [Task 4: Plant Seedlings](/restoration-playbook/reforestation/restoration-playbook-reforestation-04_Plant_Seedlings)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/04_Plant_Seedlings.md
+++ b/docs/restoration-playbook/reforestation/04_Plant_Seedlings.md
@@ -229,7 +229,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once seedlings are planted:
-→ [Task 5: Monitor Growth](../../05_Monitor_Growth)
+→ [Task 5: Monitor Growth](/restoration-playbook/reforestation/restoration-playbook-reforestation-05_Monitor_Growth)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/05_Monitor_Growth.md
+++ b/docs/restoration-playbook/reforestation/05_Monitor_Growth.md
@@ -255,7 +255,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once monitoring is established:
-→ [Task 6: Long-Term Management](../../06_Long_Term_Management)
+→ [Task 6: Long-Term Management](/restoration-playbook/reforestation/restoration-playbook-reforestation-06_Long_Term_Management)
 
 ---
 

--- a/docs/restoration-playbook/reforestation/06_Long_Term_Management.md
+++ b/docs/restoration-playbook/reforestation/06_Long_Term_Management.md
@@ -352,7 +352,7 @@ These must be followed - they are based on scientific consensus:
 - Share success stories
 - Build long-term relationships
 
-→ Reference: [Community Engagement](../community_engagement/00_Community_Engagement_Overview)
+→ Reference: [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
 ### Step 8: Documentation and Learning
 

--- a/docs/restoration-playbook/site_selection/00_Site_Selection_Overview.md
+++ b/docs/restoration-playbook/site_selection/00_Site_Selection_Overview.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 **Type:** Template/Playbook for Small Plot Restoration  
 **Status:** Template - Customize for Your Project
 
-[]( )| [Project Hub](../../00_Eco_Balance_Hub)
+[]( )| [Project Hub](/)
 
 ---
 
@@ -128,56 +128,56 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 📋 Complete 8-Step Process
 
-### [Step 1: Identify Potential Locations](../../01_Identify_Potential_Locations)
+### [Step 1: Identify Potential Locations](/restoration-playbook/site_selection/restoration-playbook-site_selection-01_Identify_Potential_Locations)
 Research and map promising regions
 - Climate and environmental criteria
 - Biodiversity priorities
 - Strategic geographic focus
 - Initial desktop screening
 
-### [Step 2: Evaluate Land Condition](../../02_Evaluate_Land_Condition)
+### [Step 2: Evaluate Land Condition](/restoration-playbook/site_selection/restoration-playbook-site_selection-02_Evaluate_Land_Condition)
 Comprehensive on-site assessment of degradation and opportunity
 - Soil health analysis
 - Vegetation assessment
 - Water availability
 - Contamination screening
 
-### [Step 3: Estimate Restoration Potential](../../03_Estimate_Restoration_Potential)
+### [Step 3: Estimate Restoration Potential](/restoration-playbook/site_selection/restoration-playbook-site_selection-03_Estimate_Restoration_Potential)
 Calculate feasibility, timeline, and likelihood of success
 - Restoration difficulty rating
 - Cost-benefit analysis
 - Timeline estimates
 - Success probability
 
-### [Step 4: Consider Accessibility](../../04_Consider_Accessibility)
+### [Step 4: Consider Accessibility](/restoration-playbook/site_selection/restoration-playbook-site_selection-04_Consider_Accessibility)
 Evaluate practical logistics and infrastructure needs
 - Road and transport access
 - Utilities availability
 - Staff and visitor accommodation
 - Emergency access
 
-### [Step 5: Research Local Regulations](../../05_Research_Local_Regulations)
+### [Step 5: Research Local Regulations](/restoration-playbook/site_selection/restoration-playbook-site_selection-05_Research_Local_Regulations)
 Understand legal requirements and constraints
 - Land use regulations
 - Environmental permits
 - Protected area designations
 - Local ordinances
 
-### [Step 6: Contact Landowners](../../06_Contact_Landowners)
+### [Step 6: Contact Landowners](/restoration-playbook/site_selection/restoration-playbook-site_selection-06_Contact_Landowners)
 Initiate negotiations and partnerships
 - Outreach strategies
 - Purchase vs partnership options
 - Legal due diligence
 - Contract negotiations
 
-### [Step 7: Visit Sites](../../07_Visit_Sites)
+### [Step 7: Visit Sites](/restoration-playbook/site_selection/restoration-playbook-site_selection-07_Visit_Sites)
 In-person inspection and verification
 - Field reconnaissance
 - Ground-truthing desktop research
 - Community and stakeholder meetings
 - Final assessment
 
-### [Step 8: Make a Shortlist](../../08_Make_Shortlist)
+### [Step 8: Make a Shortlist](/restoration-playbook/site_selection/restoration-playbook-site_selection-08_Make_Shortlist)
 Compare options and select best site(s)
 - Multi-criteria analysis
 - Risk assessment
@@ -188,15 +188,15 @@ Compare options and select best site(s)
 
 ## 🔗 Integration with Other Phases
 
-**Biodiversity:** Site characteristics determine species potential → [Biodiversity Conservation](../biodiversity/00_Biodiversity_Overview)
+**Biodiversity:** Site characteristics determine species potential → [Biodiversity Conservation](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
 
-**Soil Health:** Site condition informs restoration approach → [Soil Restoration](../soil_restoration/00_Soil_Restoration_Overview)
+**Soil Health:** Site condition informs restoration approach → [Soil Restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)
 
-**Water Management:** Site determines water needs and strategies → [Water Management](../water_management/00_Water_Management_Overview)
+**Water Management:** Site determines water needs and strategies → [Water Management](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)
 
-**Reforestation:** Site characteristics determine tree species and methods → [Reforestation](../reforestation/00_Reforestation_Overview)
+**Reforestation:** Site characteristics determine tree species and methods → [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)
 
-**Community Engagement:** Site location shapes community approach → [Community Engagement](../community_engagement/00_Community_Engagement_Overview)
+**Community Engagement:** Site location shapes community approach → [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
 ---
 
@@ -222,14 +222,14 @@ Compare options and select best site(s)
 
 ## 📚 Task Files
 
-1. [Identify Potential Locations](../../01_Identify_Potential_Locations)
-2. [Evaluate Land Condition](../../02_Evaluate_Land_Condition)
-3. [Estimate Restoration Potential](../../03_Estimate_Restoration_Potential)
-4. [Consider Accessibility](../../04_Consider_Accessibility)
-5. [Research Local Regulations](../../05_Research_Local_Regulations)
-6. [Contact Landowners](../../06_Contact_Landowners)
-7. [Visit Sites](../../07_Visit_Sites)
-8. [Make a Shortlist](../../08_Make_Shortlist)
+1. [Identify Potential Locations](/restoration-playbook/site_selection/restoration-playbook-site_selection-01_Identify_Potential_Locations)
+2. [Evaluate Land Condition](/restoration-playbook/site_selection/restoration-playbook-site_selection-02_Evaluate_Land_Condition)
+3. [Estimate Restoration Potential](/restoration-playbook/site_selection/restoration-playbook-site_selection-03_Estimate_Restoration_Potential)
+4. [Consider Accessibility](/restoration-playbook/site_selection/restoration-playbook-site_selection-04_Consider_Accessibility)
+5. [Research Local Regulations](/restoration-playbook/site_selection/restoration-playbook-site_selection-05_Research_Local_Regulations)
+6. [Contact Landowners](/restoration-playbook/site_selection/restoration-playbook-site_selection-06_Contact_Landowners)
+7. [Visit Sites](/restoration-playbook/site_selection/restoration-playbook-site_selection-07_Visit_Sites)
+8. [Make a Shortlist](/restoration-playbook/site_selection/restoration-playbook-site_selection-08_Make_Shortlist)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/01_Identify_Potential_Locations.md
+++ b/docs/restoration-playbook/site_selection/01_Identify_Potential_Locations.md
@@ -246,7 +246,7 @@ Create list of potential regions based on:
 ## Next Steps
 
 Once potential locations are identified:
-→ [Step 2: Evaluate Land Condition](../../02_Evaluate_Land_Condition)
+→ [Step 2: Evaluate Land Condition](/restoration-playbook/site_selection/restoration-playbook-site_selection-02_Evaluate_Land_Condition)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/02_Evaluate_Land_Condition.md
+++ b/docs/restoration-playbook/site_selection/02_Evaluate_Land_Condition.md
@@ -145,7 +145,7 @@ These must be followed - they are based on scientific consensus:
 - Microbial activity
 - Contamination screening
 
-→ Details: [Assess Soil Health](../soil_restoration/01_Assess_Soil_Health)
+→ Details: [Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)
 
 ### Step 3: Vegetation Survey
 
@@ -163,7 +163,7 @@ These must be followed - they are based on scientific consensus:
 - Evaluate groundwater depth
 - Check rainfall data
 
-→ Related: [Assess Water Needs](../water_management/01_Assess_Water_Needs)
+→ Related: [Assess Water Needs](/restoration-playbook/water_management/restoration-playbook-water_management-01_Assess_Water_Needs)
 
 ### Step 5: Topography & Microclimate
 
@@ -189,7 +189,7 @@ These must be followed - they are based on scientific consensus:
 - Remnant species of value
 - Connectivity to natural areas
 
-→ Details: [Assess Biodiversity](../biodiversity/01_Assess_Biodiversity)
+→ Details: [Assess Biodiversity](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-01_Assess_Biodiversity)
 
 ### Step 8: Documentation
 
@@ -224,7 +224,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once land condition is evaluated:
-→ [Step 3: Estimate Restoration Potential](../../03_Estimate_Restoration_Potential)
+→ [Step 3: Estimate Restoration Potential](/restoration-playbook/site_selection/restoration-playbook-site_selection-03_Estimate_Restoration_Potential)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/03_Estimate_Restoration_Potential.md
+++ b/docs/restoration-playbook/site_selection/03_Estimate_Restoration_Potential.md
@@ -283,7 +283,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once restoration potential is estimated:
-→ [Step 4: Consider Accessibility](../../04_Consider_Accessibility)
+→ [Step 4: Consider Accessibility](/restoration-playbook/site_selection/restoration-playbook-site_selection-04_Consider_Accessibility)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/04_Consider_Accessibility.md
+++ b/docs/restoration-playbook/site_selection/04_Consider_Accessibility.md
@@ -252,7 +252,7 @@ These must be followed - they are based on practical and operational consensus:
 ## Next Steps
 
 Once accessibility is assessed:
-→ [Step 5: Research Local Regulations](../../05_Research_Local_Regulations)
+→ [Step 5: Research Local Regulations](/restoration-playbook/site_selection/restoration-playbook-site_selection-05_Research_Local_Regulations)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/05_Research_Local_Regulations.md
+++ b/docs/restoration-playbook/site_selection/05_Research_Local_Regulations.md
@@ -297,7 +297,7 @@ These must be followed - they are based on legal and practical consensus:
 ## Next Steps
 
 Once regulations are researched:
-→ [Step 6: Contact Landowners](../../06_Contact_Landowners)
+→ [Step 6: Contact Landowners](/restoration-playbook/site_selection/restoration-playbook-site_selection-06_Contact_Landowners)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/06_Contact_Landowners.md
+++ b/docs/restoration-playbook/site_selection/06_Contact_Landowners.md
@@ -314,7 +314,7 @@ These must be followed - they are based on legal and ethical consensus:
 ## Next Steps
 
 Once landowners are contacted:
-→ [Step 7: Visit Sites](../../07_Visit_Sites)
+→ [Step 7: Visit Sites](/restoration-playbook/site_selection/restoration-playbook-site_selection-07_Visit_Sites)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/07_Visit_Sites.md
+++ b/docs/restoration-playbook/site_selection/07_Visit_Sites.md
@@ -134,7 +134,7 @@ These must be followed - they are based on practical and scientific consensus:
 - Prepare equipment and materials
 
 **Permissions:**
-- Confirm access permission from landowner → [Contact Landowners](../../06_Contact_Landowners)
+- Confirm access permission from landowner → [Contact Landowners](/restoration-playbook/site_selection/restoration-playbook-site_selection-06_Contact_Landowners)
 - Understand any restrictions or sensitive areas
 - Inform local authorities if required
 - Bring written permission if needed
@@ -294,7 +294,7 @@ These must be followed - they are based on practical and scientific consensus:
 ## Next Steps
 
 Once sites are visited:
-→ [Step 8: Make Shortlist](../../08_Make_Shortlist)
+→ [Step 8: Make Shortlist](/restoration-playbook/site_selection/restoration-playbook-site_selection-08_Make_Shortlist)
 
 ---
 

--- a/docs/restoration-playbook/site_selection/08_Make_Shortlist.md
+++ b/docs/restoration-playbook/site_selection/08_Make_Shortlist.md
@@ -130,13 +130,13 @@ These must be followed - they are based on practical and strategic consensus:
 ### Step 1: Compile All Site Data
 
 **Gather Information:**
-- Desk research findings → [Initial Research](../../01_Identify_Potential_Locations)
-- Land condition assessments → [Land Evaluation](../../02_Evaluate_Land_Condition)
-- Restoration potential estimates → [Restoration Potential](../../03_Estimate_Restoration_Potential)
-- Accessibility evaluations → [Accessibility](../../04_Consider_Accessibility)
-- Regulatory research → [Regulations](../../05_Research_Local_Regulations)
-- Landowner communication notes → [Landowner Contact](../../06_Contact_Landowners)
-- Site visit reports → [Site Visits](../../07_Visit_Sites)
+- Desk research findings → [Initial Research](/restoration-playbook/site_selection/restoration-playbook-site_selection-01_Identify_Potential_Locations)
+- Land condition assessments → [Land Evaluation](/restoration-playbook/site_selection/restoration-playbook-site_selection-02_Evaluate_Land_Condition)
+- Restoration potential estimates → [Restoration Potential](/restoration-playbook/site_selection/restoration-playbook-site_selection-03_Estimate_Restoration_Potential)
+- Accessibility evaluations → [Accessibility](/restoration-playbook/site_selection/restoration-playbook-site_selection-04_Consider_Accessibility)
+- Regulatory research → [Regulations](/restoration-playbook/site_selection/restoration-playbook-site_selection-05_Research_Local_Regulations)
+- Landowner communication notes → [Landowner Contact](/restoration-playbook/site_selection/restoration-playbook-site_selection-06_Contact_Landowners)
+- Site visit reports → [Site Visits](/restoration-playbook/site_selection/restoration-playbook-site_selection-07_Visit_Sites)
 
 **Create Master Spreadsheet:**
 - List all candidate sites

--- a/docs/restoration-playbook/soil_restoration/00_Soil_Restoration_Overview.md
+++ b/docs/restoration-playbook/soil_restoration/00_Soil_Restoration_Overview.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 **Type:** Template/Playbook for Small Plot Restoration  
 **Status:** Template - Customize for Your Project
 
-[]( )| [Project Hub](../../00_Eco_Balance_Hub)
+[]( )| [Project Hub](/)
 
 ---
 
@@ -129,32 +129,32 @@ These are the constraints based on scientific consensus that cannot be compromis
 ## 📋 Implementation Process
 
 ### Phase 1: Assessment
-1. **[Assess Soil Health](../../01_Assess_Soil_Health)** - Test soil composition, nutrients, pH, organic matter content, and biological activity
+1. **[Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)** - Test soil composition, nutrients, pH, organic matter content, and biological activity
 
 ### Phase 2: Enhancement
-2. **[Add Organic Matter](../../02_Add_Organic_Matter)** - Incorporate compost, mulch, and organic amendments
-3. **[Reduce Tillage](../../03_Reduce_Tillage)** - Minimize soil disturbance to preserve structure
-4. **[Rotate Crops](../../04_Rotate_Crops)** - Plan diverse planting sequences to improve soil health
+2. **[Add Organic Matter](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-02_Add_Organic_Matter)** - Incorporate compost, mulch, and organic amendments
+3. **[Reduce Tillage](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-03_Reduce_Tillage)** - Minimize soil disturbance to preserve structure
+4. **[Rotate Crops](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-04_Rotate_Crops)** - Plan diverse planting sequences to improve soil health
 
 ### Phase 3: Management
-5. **[Manage Pests and Diseases](../../05_Manage_Pests_Diseases)** - Implement integrated pest management for soil health
+5. **[Manage Pests and Diseases](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-05_Manage_Pests_Diseases)** - Implement integrated pest management for soil health
 
 ### Phase 4: Monitoring
-6. **[Monitor Soil Health](../../06_Monitor_Soil_Health)** - Track improvements and adjust strategies
+6. **[Monitor Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-06_Monitor_Soil_Health)** - Track improvements and adjust strategies
 
 ---
 
 ## 🔗 Integration with Other Phases
 
-**Site Selection:** Site conditions determine soil restoration approach → [Site Selection](../site_selection/00_Site_Selection_Overview)
+**Site Selection:** Site conditions determine soil restoration approach → [Site Selection](/restoration-playbook/site_selection/restoration-playbook-site_selection-00_Site_Selection_Overview)
 
-**Reforestation:** Healthy soil is essential for tree survival → [Reforestation](../reforestation/00_Reforestation_Overview)
+**Reforestation:** Healthy soil is essential for tree survival → [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)
 
-**Water Management:** Soil health affects water retention → [Water Management](../water_management/00_Water_Management_Overview)
+**Water Management:** Soil health affects water retention → [Water Management](/restoration-playbook/water_management/restoration-playbook-water_management-00_Water_Management_Overview)
 
-**Biodiversity:** Soil biodiversity supports above-ground life → [Biodiversity Conservation](../biodiversity/00_Biodiversity_Overview)
+**Biodiversity:** Soil biodiversity supports above-ground life → [Biodiversity Conservation](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
 
-**Community Engagement:** Soil work ideal for community involvement → [Community Engagement](../community_engagement/00_Community_Engagement_Overview)
+**Community Engagement:** Soil work ideal for community involvement → [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
 ---
 
@@ -180,12 +180,12 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 📚 Task Files
 
-1. [Assess Soil Health](../../01_Assess_Soil_Health)
-2. [Add Organic Matter](../../02_Add_Organic_Matter)
-3. [Reduce Tillage](../../03_Reduce_Tillage)
-4. [Rotate Crops](../../04_Rotate_Crops)
-5. [Manage Pests and Diseases](../../05_Manage_Pests_Diseases)
-6. [Monitor Soil Health](../../06_Monitor_Soil_Health)
+1. [Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)
+2. [Add Organic Matter](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-02_Add_Organic_Matter)
+3. [Reduce Tillage](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-03_Reduce_Tillage)
+4. [Rotate Crops](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-04_Rotate_Crops)
+5. [Manage Pests and Diseases](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-05_Manage_Pests_Diseases)
+6. [Monitor Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-06_Monitor_Soil_Health)
 
 ---
 

--- a/docs/restoration-playbook/soil_restoration/01_Assess_Soil_Health.md
+++ b/docs/restoration-playbook/soil_restoration/01_Assess_Soil_Health.md
@@ -256,7 +256,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once soil health is assessed:
-→ [Task 2: Add Organic Matter](../../02_Add_Organic_Matter)
+→ [Task 2: Add Organic Matter](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-02_Add_Organic_Matter)
 
 ---
 

--- a/docs/restoration-playbook/soil_restoration/02_Add_Organic_Matter.md
+++ b/docs/restoration-playbook/soil_restoration/02_Add_Organic_Matter.md
@@ -324,7 +324,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once organic matter is added:
-→ [Task 3: Reduce Tillage](../../03_Reduce_Tillage)
+→ [Task 3: Reduce Tillage](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-03_Reduce_Tillage)
 
 ---
 

--- a/docs/restoration-playbook/soil_restoration/03_Reduce_Tillage.md
+++ b/docs/restoration-playbook/soil_restoration/03_Reduce_Tillage.md
@@ -266,7 +266,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once tillage is reduced:
-→ [Task 4: Rotate Crops](../../04_Rotate_Crops)
+→ [Task 4: Rotate Crops](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-04_Rotate_Crops)
 
 ---
 

--- a/docs/restoration-playbook/soil_restoration/04_Rotate_Crops.md
+++ b/docs/restoration-playbook/soil_restoration/04_Rotate_Crops.md
@@ -308,7 +308,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once crop rotation is established:
-→ [Task 5: Manage Pests and Diseases](../../05_Manage_Pests_Diseases)
+→ [Task 5: Manage Pests and Diseases](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-05_Manage_Pests_Diseases)
 
 ---
 

--- a/docs/restoration-playbook/soil_restoration/05_Manage_Pests_Diseases.md
+++ b/docs/restoration-playbook/soil_restoration/05_Manage_Pests_Diseases.md
@@ -173,7 +173,7 @@ These must be followed - they are based on scientific consensus:
 ### Step 3: Implement Preventive Practices
 
 **Cultural practices:**
-- Crop rotation → [Rotate Crops](../../04_Rotate_Crops)
+- Crop rotation → [Rotate Crops](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-04_Rotate_Crops)
 - Sanitation (remove infected material)
 - Proper timing (plant when conditions favor plants, not pests)
 - Appropriate spacing (good air circulation)
@@ -303,7 +303,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once pest and disease management is established:
-→ [Task 6: Monitor Soil Health](../../06_Monitor_Soil_Health)
+→ [Task 6: Monitor Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-06_Monitor_Soil_Health)
 
 ---
 

--- a/docs/restoration-playbook/soil_restoration/06_Monitor_Soil_Health.md
+++ b/docs/restoration-playbook/soil_restoration/06_Monitor_Soil_Health.md
@@ -130,7 +130,7 @@ These must be followed - they are based on scientific consensus:
 ### Step 1: Establish Baseline and Monitoring Framework
 
 **Use initial assessment as baseline:**
-- Refer to data from [Assess Soil Health](../../01_Assess_Soil_Health)
+- Refer to data from [Assess Soil Health](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-01_Assess_Soil_Health)
 - Establish Year 0 baseline for all key indicators
 - Document starting conditions thoroughly
 - Take baseline photos from fixed points

--- a/docs/restoration-playbook/water_management/00_Water_Management_Overview.md
+++ b/docs/restoration-playbook/water_management/00_Water_Management_Overview.md
@@ -10,7 +10,7 @@ sidebar_position: 0
 **Type:** Template/Playbook for Small Plot Restoration  
 **Status:** Template - Customize for Your Project
 
-[]( )| [Project Hub](../../00_Eco_Balance_Hub)
+[]( )| [Project Hub](/)
 
 ---
 
@@ -130,32 +130,32 @@ These are the constraints based on scientific consensus that cannot be compromis
 ## 📋 Implementation Process
 
 ### Phase 1: Assessment
-1. **[Assess Water Needs](../../01_Assess_Water_Needs)** - Understand precipitation patterns, soil water-holding capacity, plant water requirements, and current water availability
+1. **[Assess Water Needs](/restoration-playbook/water_management/restoration-playbook-water_management-01_Assess_Water_Needs)** - Understand precipitation patterns, soil water-holding capacity, plant water requirements, and current water availability
 
 ### Phase 2: Capture & Storage
-2. **[Rainwater Harvesting](../../02_Rainwater_Harvesting)** - Implement systems to capture and direct rainfall
-3. **[Build Water Storage Structures](../../03_Build_Water_Storage_Structures)** - Create ponds, swales, tanks, or other storage solutions
+2. **[Rainwater Harvesting](/restoration-playbook/water_management/restoration-playbook-water_management-02_Rainwater_Harvesting)** - Implement systems to capture and direct rainfall
+3. **[Build Water Storage Structures](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)** - Create ponds, swales, tanks, or other storage solutions
 
 ### Phase 3: Efficient Use
-4. **[Efficient Irrigation](../../04_Efficient_Irrigation)** - Design and implement water-wise irrigation when needed
-5. **[Drought Management](../../05_Drought_Management)** - Prepare for and manage through dry periods
+4. **[Efficient Irrigation](/restoration-playbook/water_management/restoration-playbook-water_management-04_Efficient_Irrigation)** - Design and implement water-wise irrigation when needed
+5. **[Drought Management](/restoration-playbook/water_management/restoration-playbook-water_management-05_Drought_Management)** - Prepare for and manage through dry periods
 
 ### Phase 4: Monitoring
-6. **[Monitor Water Use](../../06_Monitor_Water_Use)** - Track water inputs, usage, and efficiency over time
+6. **[Monitor Water Use](/restoration-playbook/water_management/restoration-playbook-water_management-06_Monitor_Water_Use)** - Track water inputs, usage, and efficiency over time
 
 ---
 
 ## 🔗 Integration with Other Phases
 
-**Site Selection:** Site determines water availability and needs → [Site Selection](../site_selection/00_Site_Selection_Overview)
+**Site Selection:** Site determines water availability and needs → [Site Selection](/restoration-playbook/site_selection/restoration-playbook-site_selection-00_Site_Selection_Overview)
 
-**Soil Health:** Soil health affects water retention → [Soil Restoration](../soil_restoration/00_Soil_Restoration_Overview)
+**Soil Health:** Soil health affects water retention → [Soil Restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview)
 
-**Reforestation:** Trees need water for establishment → [Reforestation](../reforestation/00_Reforestation_Overview)
+**Reforestation:** Trees need water for establishment → [Reforestation](/restoration-playbook/reforestation/restoration-playbook-reforestation-00_Reforestation_Overview)
 
-**Biodiversity:** Water features create habitat diversity → [Biodiversity Conservation](../biodiversity/00_Biodiversity_Overview)
+**Biodiversity:** Water features create habitat diversity → [Biodiversity Conservation](/restoration-playbook/biodiversity/restoration-playbook-biodiversity-00_Biodiversity_Overview)
 
-**Community Engagement:** Water management can provide community benefits → [Community Engagement](../community_engagement/00_Community_Engagement_Overview)
+**Community Engagement:** Water management can provide community benefits → [Community Engagement](/restoration-playbook/community_engagement/restoration-playbook-community_engagement-00_Community_Engagement_Overview)
 
 ---
 
@@ -181,12 +181,12 @@ These are the constraints based on scientific consensus that cannot be compromis
 
 ## 📚 Task Files
 
-1. [Assess Water Needs](../../01_Assess_Water_Needs)
-2. [Rainwater Harvesting](../../02_Rainwater_Harvesting)
-3. [Build Water Storage Structures](../../03_Build_Water_Storage_Structures)
-4. [Efficient Irrigation](../../04_Efficient_Irrigation)
-5. [Drought Management](../../05_Drought_Management)
-6. [Monitor Water Use](../../06_Monitor_Water_Use)
+1. [Assess Water Needs](/restoration-playbook/water_management/restoration-playbook-water_management-01_Assess_Water_Needs)
+2. [Rainwater Harvesting](/restoration-playbook/water_management/restoration-playbook-water_management-02_Rainwater_Harvesting)
+3. [Build Water Storage Structures](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)
+4. [Efficient Irrigation](/restoration-playbook/water_management/restoration-playbook-water_management-04_Efficient_Irrigation)
+5. [Drought Management](/restoration-playbook/water_management/restoration-playbook-water_management-05_Drought_Management)
+6. [Monitor Water Use](/restoration-playbook/water_management/restoration-playbook-water_management-06_Monitor_Water_Use)
 
 ---
 

--- a/docs/restoration-playbook/water_management/01_Assess_Water_Needs.md
+++ b/docs/restoration-playbook/water_management/01_Assess_Water_Needs.md
@@ -275,7 +275,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once water needs are assessed:
-→ [Task 2: Rainwater Harvesting](../../02_Rainwater_Harvesting)
+→ [Task 2: Rainwater Harvesting](/restoration-playbook/water_management/restoration-playbook-water_management-02_Rainwater_Harvesting)
 
 ---
 

--- a/docs/restoration-playbook/water_management/02_Rainwater_Harvesting.md
+++ b/docs/restoration-playbook/water_management/02_Rainwater_Harvesting.md
@@ -212,7 +212,7 @@ Simplified: **Catchment Area (m²) × Rainfall (mm) = Liters captured**
 - Inline filters before storage
 - Regular cleaning essential
 
-**5. Storage (see [Build Water Storage Structures](../../03_Build_Water_Storage_Structures)):**
+**5. Storage (see [Build Water Storage Structures](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)):**
 - Tanks, cisterns, or ponds
 - Size based on supply and demand analysis
 - Covered to prevent algae, mosquitoes, evaporation
@@ -354,7 +354,7 @@ Simplified: **Catchment Area (m²) × Rainfall (mm) = Liters captured**
 ## Next Steps
 
 Once rainwater harvesting is implemented:
-→ [Task 3: Build Water Storage Structures](../../03_Build_Water_Storage_Structures)
+→ [Task 3: Build Water Storage Structures](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)
 
 ---
 

--- a/docs/restoration-playbook/water_management/03_Build_Water_Storage_Structures.md
+++ b/docs/restoration-playbook/water_management/03_Build_Water_Storage_Structures.md
@@ -340,7 +340,7 @@ These must be followed - they are based on scientific and practical consensus:
 ## Next Steps
 
 Once water storage is built:
-→ [Task 4: Efficient Irrigation](../../04_Efficient_Irrigation)
+→ [Task 4: Efficient Irrigation](/restoration-playbook/water_management/restoration-playbook-water_management-04_Efficient_Irrigation)
 
 ---
 

--- a/docs/restoration-playbook/water_management/04_Efficient_Irrigation.md
+++ b/docs/restoration-playbook/water_management/04_Efficient_Irrigation.md
@@ -131,7 +131,7 @@ These must be followed - they are based on scientific consensus:
 ### Step 1: Assess Irrigation Needs
 
 **Review water assessment:**
-- Refer to [Assess Water Needs](../../01_Assess_Water_Needs)
+- Refer to [Assess Water Needs](/restoration-playbook/water_management/restoration-playbook-water_management-01_Assess_Water_Needs)
 - Identify areas requiring supplemental water
 - Determine irrigation duration (establishment only vs. ongoing)
 - Calculate peak demand periods
@@ -301,7 +301,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once irrigation is established:
-→ [Task 5: Drought Management](../../05_Drought_Management)
+→ [Task 5: Drought Management](/restoration-playbook/water_management/restoration-playbook-water_management-05_Drought_Management)
 
 ---
 

--- a/docs/restoration-playbook/water_management/05_Drought_Management.md
+++ b/docs/restoration-playbook/water_management/05_Drought_Management.md
@@ -155,8 +155,8 @@ These must be followed - they are based on scientific consensus:
 **Site-level strategies:**
 
 **Maximize water capture and retention:**
-- Implement all [rainwater harvesting](../../02_Rainwater_Harvesting) strategies
-- Build adequate [water storage](../../03_Build_Water_Storage_Structures)
+- Implement all [rainwater harvesting](/restoration-playbook/water_management/restoration-playbook-water_management-02_Rainwater_Harvesting) strategies
+- Build adequate [water storage](/restoration-playbook/water_management/restoration-playbook-water_management-03_Build_Water_Storage_Structures)
 - Create swales and berms to slow and sink water
 - Increase soil organic matter (each 1% holds significant water)
 - Mulch all bare soil to reduce evaporation
@@ -179,7 +179,7 @@ These must be followed - they are based on scientific consensus:
 
 **Improve soil water efficiency:**
 - Deep, well-structured soil holds more water
-- Follow all [soil restoration](../soil_restoration/00_Soil_Restoration_Overview) practices
+- Follow all [soil restoration](/restoration-playbook/soil_restoration/restoration-playbook-soil_restoration-00_Soil_Restoration_Overview) practices
 - Mycorrhizal fungi extend water access
 - Reduce compaction for better infiltration
 - Clay soils hold water better than sand
@@ -202,7 +202,7 @@ These must be followed - they are based on scientific consensus:
 ### Step 4: Implement Water Conservation
 
 **Irrigation efficiency:**
-- Use efficient irrigation methods → [Efficient Irrigation](../../04_Efficient_Irrigation)
+- Use efficient irrigation methods → [Efficient Irrigation](/restoration-playbook/water_management/restoration-playbook-water_management-04_Efficient_Irrigation)
 - Drip irrigation for targeted delivery
 - Water only when necessary
 - Monitor soil moisture
@@ -296,7 +296,7 @@ These must be followed - they are based on scientific consensus:
 ## Next Steps
 
 Once drought management is established:
-→ [Task 6: Monitor Water Use](../../06_Monitor_Water_Use)
+→ [Task 6: Monitor Water Use](/restoration-playbook/water_management/restoration-playbook-water_management-06_Monitor_Water_Use)
 
 ---
 


### PR DESCRIPTION
- Fix Quick Navigation section in intro.md: add working Docusaurus links to all navigation items
- Fix all broken relative links in restoration-playbook (41 files): convert ../../ paths to proper Docusaurus document IDs
- Update restoration-playbook README.md: fix all 44 task links to use correct document IDs
- Add internal cross-references: link related topics (soil, water, biodiversity) where mentioned
- Convert all relative paths to absolute Docusaurus paths for proper navigation

All links now use format: /restoration-playbook/phase_name/restoration-playbook-phase_name-XX_Task_Name