### PR TITLE
Fix formatting: Add blank line between Countries and Key Issues sections

### DIFF
--- a/docs/vision-strategy/project-vision.md
+++ b/docs/vision-strategy/project-vision.md
@@ -136,6 +136,7 @@ Europe offers diverse restoration opportunities across multiple climate zones:
 
 ### Mediterranean Region Challenges
 **Countries**: Portugal, Spain, Southern France, Greece, Italy
+
 **Key Issues**:
 - Increased drought frequency and severity
 - Wildfire risk escalating
@@ -144,6 +145,7 @@ Europe offers diverse restoration opportunities across multiple climate zones:
 
 ### Temperate Region Challenges
 **Countries**: Germany, Northern France, Poland, Czech Republic, Austria
+
 **Key Issues**:
 - Forest degradation from monoculture forestry
 - Agricultural intensification reducing biodiversity

--- a/strategic/02_Project_Vision.md
+++ b/strategic/02_Project_Vision.md
@@ -130,6 +130,7 @@ Europe offers diverse restoration opportunities across multiple climate zones:
 
 ### Mediterranean Region Challenges
 **Countries**: Portugal, Spain, Southern France, Greece, Italy
+
 **Key Issues**:
 - Increased drought frequency and severity
 - Wildfire risk escalating
@@ -138,6 +139,7 @@ Europe offers diverse restoration opportunities across multiple climate zones:
 
 ### Temperate Region Challenges
 **Countries**: Germany, Northern France, Poland, Czech Republic, Austria
+
 **Key Issues**:
 - Forest degradation from monoculture forestry
 - Agricultural intensification reducing biodiversity


### PR DESCRIPTION
- Added blank line between 'Countries:' and 'Key Issues:' in Mediterranean and Temperate region sections
- Fixes rendering issue where text appeared on same line
- Applied to both project-vision.md and 02_Project_Vision.md