### PR TITLE
Fix verification workflow: add npm install fallback and handle missin…

### DIFF
--- a/.github/workflows/verify-deployment.yml
+++ b/.github/workflows/verify-deployment.yml
@@ -25,7 +25,8 @@ jobs:
           node-version: '18'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: |
+          npm ci --ignore-scripts || npm install --ignore-scripts
 
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
@@ -33,7 +34,7 @@ jobs:
       - name: Run deployment tests
         id: test
         run: |
-          BASE_URL="https://presiannedyalkov.github.io/eco-balance-documentation" npx playwright test tests/deployment.spec.js
+          BASE_URL="https://presiannedyalkov.github.io/eco-balance-documentation" npx playwright test tests/deployment.spec.js --reporter=html,list
         continue-on-error: true
         env:
           BASE_URL: https://presiannedyalkov.github.io/eco-balance-documentation
@@ -57,6 +58,7 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+          if-no-files-found: ignore
 
   rollback:
     name: Rollback Deployment

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -16,7 +16,7 @@ module.exports = defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI ? 'html' : 'list',
+  reporter: process.env.CI ? [['html'], ['list']] : 'list',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
…g test reports

- Add fallback to npm install if npm ci fails (consistent with deploy workflow)
- Make test results upload conditional (ignore if no files found)
- Configure Playwright to use both html and list reporters in CI
- This fixes the 'Install dependencies' failure and 'No files found' warning