### PR TITLE
fix: properly detect test failures in verify deployment workflow

### DIFF
--- a/.github/workflows/verify-deployment.yml
+++ b/.github/workflows/verify-deployment.yml
@@ -90,7 +90,11 @@ jobs:
         id: test
         run: |
           DEPLOY_URL="${{ steps.url.outputs.deploy_url }}"
+          set +e  # Don't exit on error
           BASE_URL="$DEPLOY_URL" npx playwright test tests/deployment.spec.js --reporter=html,list
+          TEST_EXIT_CODE=$?
+          echo "test_exit_code=$TEST_EXIT_CODE" >> $GITHUB_OUTPUT
+          # Don't exit here - let continue-on-error handle it
         continue-on-error: true
         env:
           BASE_URL: ${{ steps.url.outputs.deploy_url }}
@@ -99,9 +103,13 @@ jobs:
       - name: Check test results
         id: check_results
         run: |
-          if [ "${{ steps.test.outcome }}" != "success" ]; then
+          # Get the exit code from the test step
+          TEST_EXIT_CODE="${{ steps.test.outputs.test_exit_code }}"
+          
+          # Check if tests actually failed (exit code != 0)
+          if [ "$TEST_EXIT_CODE" != "0" ] && [ -n "$TEST_EXIT_CODE" ]; then
             echo "tests_failed=true" >> $GITHUB_OUTPUT
-            echo "❌ Deployment verification tests failed!"
+            echo "❌ Deployment verification tests failed! (Exit code: $TEST_EXIT_CODE)"
             exit 1
           else
             echo "tests_failed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/verify-deployment-test-detection`, this PR is classified as: **Bug fix**

---

## Problem

The verify deployment workflow was not correctly detecting test failures. The check step was comparing `steps.test.outcome` to "success", but because the test step has `continue-on-error: true`, the outcome is always "success" even when tests fail.

## Solution

- Capture the actual Playwright test exit code in `GITHUB_OUTPUT` as `test_exit_code`
- Check the exit code in the "Check test results" step instead of the outcome
- Use `set +e` to prevent early exit while still capturing the exit code

## Changes

- Modified `.github/workflows/verify-deployment.yml`:
  - Test step now captures exit code: `TEST_EXIT_CODE=$?` and stores it
  - Check step reads `steps.test.outputs.test_exit_code` and fails if != 0

## Testing

This fix ensures that when Playwright tests fail (exit code != 0), the workflow will correctly detect the failure and trigger the rollback job.

## Related

- Fixes issue where verify deployment workflow was not detecting test failures correctly