### PR TITLE
fix: add src/** to deploy workflow paths

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - 'docs/**'
       - 'strategic/**'
       - 'website/**'
+      - 'src/**'
       - 'docusaurus.config.js'
       - 'sidebars.js'
       - 'package.json'


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/add-src-to-deploy-paths`, this PR is classified as: **Bug fix**

---

## Problem

The deployment workflow didn't trigger when PR #175 was merged because the `src/` directory is not included in the `paths` filter. Changes to `src/clientModules.js` and other source files don't trigger deployment.

## Solution

- Added `src/**` to the paths filter in `.github/workflows/deploy.yml`
- Now changes to source files (clientModules, components, CSS) will trigger deployment

## Changes

- Modified `.github/workflows/deploy.yml`:
  - Added `src/**` to the paths list

## Impact

- Source code changes will now trigger deployments
- Fixes the issue where search bar fixes didn't deploy automatically

## Next Steps

After merging this, we should manually trigger a deployment or make a small change to trigger it, so the search bar fix from PR #175 gets deployed.