### PR TITLE
fix: explicitly configure clientModules in Docusaurus 3.x

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -80,6 +80,12 @@ const config = {
   // Sentry integration removed - to be added later
   // See SENTRY_SETUP.md for future integration
 
+  // Client-side modules - explicitly configure clientModules.js
+  // Docusaurus 3.x requires explicit configuration (does NOT auto-load src/clientModules.js)
+  clientModules: [
+    require.resolve('./src/clientModules.js'),
+  ],
+
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/add-clientmodules-config`, this PR is classified as: **Bug fix**

---

## Problem

The Meilisearch search bar is not visible because `clientModules.js` is not loading. The comprehensive test revealed:
- ❌ NO clientModules logs in console
- ❌ Wrapper div exists but is empty (no React component mounted)
- ❌ No clientModules references in HTML source
- ❌ No clientModules-related network requests

**Root Cause:** Docusaurus 3.x does NOT automatically load `src/clientModules.js`. It must be explicitly configured in `docusaurus.config.js`.

## Solution

Added explicit `clientModules` configuration to `docusaurus.config.js`:

```javascript
clientModules: [
  require.resolve('./src/clientModules.js'),
],
```

## Changes

- Modified `docusaurus.config.js`:
  - Added `clientModules` array with explicit path to `src/clientModules.js`
  - Added comment explaining that Docusaurus 3.x requires explicit configuration

## Testing

After deployment:
1. Check browser console for `🔍 [clientModules]` logs
2. Verify `window.clientModulesDebug` exists
3. Verify search bar is visible in navbar
4. Run: `node tests/debug-deployed-site.js` to verify

## Related

- Fixes search bar not visible issue
- Part of Meilisearch integration
- Comprehensive debugging added in PR #177