### PR TITLE
Add Meilisearch master key support for indexing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,11 @@ jobs:
           SITE_URL: ${{ env.CUSTOM_DOMAIN_URL || vars.CUSTOM_DOMAIN_URL || 'https://docs.eco-balance.cc' }}
           # Meilisearch configuration (optional - defaults are in docusaurus.config.js)
           MEILISEARCH_HOST: ${{ vars.MEILISEARCH_HOST || env.MEILISEARCH_HOST || 'https://search.eco-balance.cc' }}
+          # Search key for frontend (read-only, safe to expose)
           MEILISEARCH_SEARCH_KEY: ${{ secrets.MEILISEARCH_SEARCH_KEY || vars.MEILISEARCH_SEARCH_KEY || 'e1eebc3950796ae3ead1c39d2c80f4148212c344a36fb6ba9e9ec91d7a7f4489' }}
+          # Master key for indexing during build (write permissions, keep secret!)
+          # This is only used during build to index content, not exposed to frontend
+          MEILISEARCH_MASTER_KEY: ${{ secrets.MEILISEARCH_MASTER_KEY }}
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/MEILISEARCH_INDEXING.md
+++ b/MEILISEARCH_INDEXING.md
@@ -1,0 +1,124 @@
+# Meilisearch Indexing Setup
+
+## Problem
+
+The search bar is visible but returns no results because the index is empty. This happens because:
+
+1. **Indexing requires write permissions** - The build process needs to add documents to Meilisearch
+2. **Search-only keys can't write** - The current setup uses a search-only key which is safe for frontend but can't index
+3. **Indexing happens during build** - Content is indexed when `npm run build` runs in GitHub Actions
+
+## Solution
+
+Use **two different API keys**:
+
+1. **Master Key** (for indexing during build) - Has write permissions, kept secret in GitHub Secrets
+2. **Search Key** (for frontend) - Read-only, safe to expose in frontend code
+
+## Setup Instructions
+
+### Step 1: Get Your Meilisearch Master Key
+
+If you're self-hosting Meilisearch, you should have a master key. This is the key you use to:
+- Create indexes
+- Add documents
+- Configure settings
+
+**⚠️ Security:** Keep this key secret! Never commit it to the repository.
+
+### Step 2: Add Master Key to GitHub Secrets
+
+1. Go to your repository: https://github.com/presiannedyalkov/eco-balance-documentation
+2. Navigate to: **Settings** → **Secrets and variables** → **Actions**
+3. Click **New repository secret**
+4. Name: `MEILISEARCH_MASTER_KEY`
+5. Value: Your Meilisearch master key
+6. Click **Add secret**
+
+### Step 3: Verify Search Key
+
+The search key (read-only) is already configured. It's safe to use in the frontend because it only has read permissions.
+
+Current search key location:
+- GitHub Secret: `MEILISEARCH_SEARCH_KEY` (if set)
+- Or default: `e1eebc3950796ae3ead1c39d2c80f4148212c344a36fb6ba9e9ec91d7a7f4489`
+
+### Step 4: How It Works
+
+**During Build (GitHub Actions):**
+- Uses `MEILISEARCH_MASTER_KEY` (from secrets) to index all documentation pages
+- This key has write permissions, so it can add documents to the index
+
+**In Frontend (Browser):**
+- Uses `MEILISEARCH_SEARCH_KEY` (read-only) to search the index
+- This key is safe to expose because it can only read, not modify
+
+### Step 5: Test Indexing
+
+After adding the master key:
+
+1. **Trigger a new deployment** (push to main or manually trigger workflow)
+2. **Check build logs** for indexing messages:
+   ```
+   🔍 Meilisearch: Starting indexing...
+   ✅ Indexed batch 1/3
+   ✅ Meilisearch: Indexed 45 documents
+   ```
+3. **Test search** on https://docs.eco-balance.cc/ - should now return results!
+
+## Troubleshooting
+
+### "Index not found" error
+
+If you see `Index 'eco-balance-docs' not found`:
+- The index will be created automatically on first indexing
+- Make sure `MEILISEARCH_MASTER_KEY` is set correctly
+- Check that Meilisearch is accessible from GitHub Actions
+
+### "API key invalid" error
+
+- Verify the master key is correct
+- Check that the key has write permissions
+- Ensure the key is set in GitHub Secrets (not Variables)
+
+### Indexing skipped warnings
+
+If you see:
+```
+⚠️  Meilisearch indexing skipped: Key doesn't have write permissions
+```
+
+This means:
+- The master key is not set, OR
+- The wrong key is being used (search key instead of master key)
+
+**Fix:** Add `MEILISEARCH_MASTER_KEY` to GitHub Secrets
+
+## Security Best Practices
+
+1. ✅ **Master key in secrets** - Never commit master key to code
+2. ✅ **Search key in frontend** - Safe to expose, read-only
+3. ✅ **HTTPS only** - Meilisearch should be behind HTTPS
+4. ✅ **Rate limiting** - Consider rate limiting if public
+
+## Manual Indexing (Alternative)
+
+If you prefer to index manually instead of during build:
+
+1. Remove `MEILISEARCH_MASTER_KEY` from GitHub Secrets
+2. Run indexing manually:
+   ```bash
+   MEILISEARCH_MASTER_KEY=your_master_key npm run build
+   ```
+3. Or use a separate script to index after deployment
+
+## Related Files
+
+- `src/plugins/meilisearch-plugin.js` - Indexing plugin
+- `.github/workflows/deploy.yml` - Build workflow
+- `docusaurus.config.js` - Meilisearch configuration
+
+---
+
+**Last Updated:** November 17, 2025
+

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -71,6 +71,10 @@ const config = {
         // Search-only key (safe to use in frontend)
         // Set via environment variable: MEILISEARCH_SEARCH_KEY
         searchKey: process.env.MEILISEARCH_SEARCH_KEY || 'e1eebc3950796ae3ead1c39d2c80f4148212c344a36fb6ba9e9ec91d7a7f4489',
+        // Master key for indexing (write permissions) - only used during build
+        // Set via environment variable: MEILISEARCH_MASTER_KEY
+        // This should be kept secret and only used in CI/CD, not in frontend
+        masterKey: process.env.MEILISEARCH_MASTER_KEY,
         indexName: 'eco-balance-docs',
         batchSize: 100,
       },

--- a/src/plugins/meilisearch-plugin.js
+++ b/src/plugins/meilisearch-plugin.js
@@ -10,12 +10,22 @@ function pluginMeilisearch(context, options) {
   const {
     host,
     searchKey,
+    masterKey, // Optional: for indexing (write permissions)
     indexName = 'docs',
     batchSize = 100,
   } = options;
 
-  if (!host || !searchKey) {
-    console.warn('⚠️  Meilisearch plugin: host and searchKey are required');
+  if (!host) {
+    console.warn('⚠️  Meilisearch plugin: host is required');
+    return {};
+  }
+
+  // For indexing, use masterKey if available, otherwise searchKey
+  // masterKey has write permissions needed for indexing
+  const indexingKey = masterKey || searchKey;
+  
+  if (!indexingKey) {
+    console.warn('⚠️  Meilisearch plugin: searchKey or masterKey is required');
     return {};
   }
 
@@ -38,9 +48,11 @@ function pluginMeilisearch(context, options) {
         const path = require('path');
         const { glob } = require('glob');
 
+        // Use masterKey for indexing (has write permissions)
+        // If masterKey not provided, try searchKey (may fail if read-only)
         const client = new MeiliSearch({
           host: host,
-          apiKey: searchKey,
+          apiKey: indexingKey,
         });
 
         const index = client.index(indexName);


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/add-meilisearch-master-key`, this PR is classified as: **Bug fix**

---

This PR adds support for using a master key during build to index content in Meilisearch.

**Problem:**
- Search returns no results because the index is empty
- Indexing requires write permissions, but only search-only key was available
- Build logs show: 'Key doesn't have write permissions'

**Solution:**
- Updated plugin to accept `masterKey` for indexing (write permissions)
- Updated GitHub Actions workflow to use `MEILISEARCH_MASTER_KEY` secret
- Master key is only used during build, never exposed to frontend
- Search key remains read-only for frontend use

**Changes:**
- `src/plugins/meilisearch-plugin.js` - Accept masterKey parameter
- `.github/workflows/deploy.yml` - Use MEILISEARCH_MASTER_KEY secret
- `docusaurus.config.js` - Pass masterKey to plugin
- `MEILISEARCH_INDEXING.md` - Documentation

**Note:** The master key has already been added to GitHub Secrets as `MEILISEARCH_MASTER_KEY`.

After merge, the next deployment will automatically index all documentation pages.