### PR TITLE
fix: remove esbuild-loader webpack config causing build failure

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -234,18 +234,6 @@ const config = {
         darkTheme: darkCodeTheme,
       },
     }),
-
-  // Webpack configuration to inject Sentry DSN at build time
-  // This makes process.env.SENTRY_DSN available in the browser bundle
-  webpack: {
-    jsLoader: (isServer) => ({
-      loader: require.resolve('esbuild-loader'),
-      options: {
-        loader: 'tsx',
-        target: isServer ? 'node12' : 'es2017',
-      },
-    }),
-  },
 };
 
 module.exports = config;


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/remove-esbuild-loader-config`, this PR is classified as: **Bug fix**

---

The webpack jsLoader configuration was trying to use esbuild-loader which is not installed. This config is not necessary as:

1. Sentry DSN injection is handled by the webpack plugin (DefinePlugin)
2. Docusaurus has its own default loaders that work fine

This fixes the build failure on main branch that's preventing deployments.

Fixes the build error:
```
Error: Cannot find module 'esbuild-loader'
at jsLoader (/docusaurus.config.js:242:23)
```