### PR TITLE
fix: Fix CodeQL alerts #59 and #60 using sanitizeForLog helper

### DIFF
--- a/scripts/test-pages-http.js
+++ b/scripts/test-pages-http.js
@@ -12,6 +12,14 @@ const PORT = 3023;
 // For local development, baseUrl is '/', for production it's '/eco-balance-documentation/'
 const BASE_PATH = process.env.NODE_ENV === 'production' ? '/eco-balance-documentation' : '';
 
+// Sanitize user input for logging to prevent log injection
+function sanitizeForLog(input, maxLength = 200) {
+  return String(input || '')
+    .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+    .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
+    .substring(0, maxLength); // Limit length
+}
+
 // Pages to test
 const PAGES_TO_TEST = [
   '/', // Homepage
@@ -144,15 +152,8 @@ async function runTests() {
       console.log('❌ Failed:', `${failed}/${results.length}`);
       console.log('\nFailed pages:');
       results.filter(r => r.status === 'failed').forEach(r => {
-        // Sanitize error message and URL to prevent log injection - remove all control characters and limit length
-        // Sanitize directly from source in console call to ensure CodeQL recognizes it
-        console.log('  -', String(String(r?.url || '')
-          .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
-          .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-          .substring(0, 100)), ':', String(String(r?.error || '') // Limit length
-          .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
-          .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-          .substring(0, 200))); // Limit length
+        // Sanitize error message and URL to prevent log injection
+        console.log('  -', sanitizeForLog(r?.url, 100), ':', sanitizeForLog(r?.error));
       });
       console.log('\n💡 Make sure the server is running: npm start');
       process.exit(1);

--- a/scripts/update-security-status.js
+++ b/scripts/update-security-status.js
@@ -18,6 +18,14 @@ const REPO_OWNER = 'presiannedyalkov';
 const REPO_NAME = 'eco-balance-documentation';
 const README_PATH = path.join(__dirname, '..', 'README.md');
 
+// Sanitize user input for logging to prevent log injection
+function sanitizeForLog(input) {
+  return String(input || '')
+    .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+    .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
+    .substring(0, 200); // Limit length
+}
+
 if (!GITHUB_TOKEN) {
   console.error('❌ Error: GITHUB_TOKEN environment variable is required');
   console.error('Usage: GITHUB_TOKEN=your_token node scripts/update-security-status.js');
@@ -130,12 +138,8 @@ async function getDependabotAlerts() {
 
     return counts;
   } catch (error) {
-    // Sanitize error message to prevent log injection - remove all control characters and limit length
-    // Sanitize directly from source in console call to ensure CodeQL recognizes it
-    console.warn('⚠️  Could not fetch Dependabot alerts:', String(String(error?.message || 'Unknown error')
-      .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
-      .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-      .substring(0, 200))); // Limit length
+    // Sanitize error message to prevent log injection
+    console.warn('⚠️  Could not fetch Dependabot alerts:', sanitizeForLog(error?.message || 'Unknown error'));
     return { critical: 0, high: 0, moderate: 0, low: 0, total: 0, error: true };
   }
 }


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/codeql-alerts-59-60`, this PR is classified as: **Bug fix**

---

## Changes

This PR fixes CodeQL alerts by using a dedicated `sanitizeForLog()` helper function that CodeQL can recognize:

- ✅ Fixed alert #59: `scripts/test-pages-http.js:152`
- ✅ Fixed alert #60: `scripts/update-security-status.js:135`

## Fix Strategy

CodeQL was flagging inline sanitization even when wrapped in `String()`. The fix creates a dedicated `sanitizeForLog()` helper function that:
1. Takes user input as a parameter
2. Sanitizes it (removes control characters, newlines, limits length)
3. Returns a safe string

Using this helper function allows CodeQL to trace the sanitization pattern from user input through the function to the console output.

## Verification

- ✅ Local checker passes: `npm run check:codeql:simple` (0 issues)
- ✅ All fixes tested locally

## Related

Fixes CodeQL alerts #59 and #60.