### PR TITLE
fix: Fix CodeQL alerts #12, #19, #39, #63 with inline sanitization

### DIFF
--- a/scripts/check-github-actions.js
+++ b/scripts/check-github-actions.js
@@ -147,12 +147,12 @@ async function checkWorkflows() {
 
   } catch (error) {
     // Sanitize error message to prevent log injection - remove all control characters and limit length
-    const rawMessage = String(error?.message || 'Unknown error');
-    // Sanitize inline to ensure CodeQL recognizes it, then wrap in String() for CodeQL
-    const sanitizedError = String(String(rawMessage
+    // Sanitize error message to prevent log injection
+    // Inline sanitization so CodeQL can trace it: remove newlines and control characters
+    const sanitizedError = String(error?.message || 'Unknown error')
       .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
       .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-      .substring(0, 200))); // Limit length
+      .substring(0, 200); // Limit length
     // Use separate arguments - CodeQL recognizes sanitization when values are passed separately
     console.error('❌ Error checking workflows:', sanitizedError);
     if (sanitizedError.includes('401') || sanitizedError.includes('403')) {

--- a/scripts/test-pages-http.js
+++ b/scripts/test-pages-http.js
@@ -146,12 +146,16 @@ async function runTests() {
       console.log('\nFailed pages:');
       results.filter(r => r.status === 'failed').forEach(r => {
         // Sanitize error message and URL to prevent log injection
-        // CodeQL needs to see sanitization happen - sanitize inline and wrap in String()
-        const url = r?.url || '';
-        const error = r?.error || '';
-        const sanitizedUrl = String(sanitizeForLog(url, 100));
-        const sanitizedError = String(sanitizeForLog(error));
-        console.log('  -', sanitizedUrl, ':', sanitizedError);
+        // Inline sanitization so CodeQL can trace it: remove newlines and control characters
+        const url = String(r?.url || '')
+          .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+          .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
+          .substring(0, 100); // Limit length
+        const error = String(r?.error || '')
+          .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+          .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
+          .substring(0, 200); // Limit length
+        console.log('  -', url, ':', error);
       });
       console.log('\n💡 Make sure the server is running: npm start');
       process.exit(1);

--- a/scripts/update-security-status.js
+++ b/scripts/update-security-status.js
@@ -94,13 +94,12 @@ async function getCodeQLAlerts() {
 
     return counts;
   } catch (error) {
-    // Sanitize error message to prevent log injection - remove all control characters and limit length
-    const rawMessage = String(error?.message || 'Unknown error');
-    // Sanitize inline to ensure CodeQL recognizes it, then wrap in String() for CodeQL
-    const sanitizedError = String(String(rawMessage
+    // Sanitize error message to prevent log injection
+    // Inline sanitization so CodeQL can trace it: remove newlines and control characters
+    const sanitizedError = String(error?.message || 'Unknown error')
       .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
       .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-      .substring(0, 200))); // Limit length
+      .substring(0, 200); // Limit length
     // Use separate arguments - CodeQL recognizes sanitization when values are passed separately
     console.warn('⚠️  Could not fetch CodeQL alerts:', sanitizedError);
     return { critical: 0, high: 0, medium: 0, low: 0, note: 0, total: 0, error: true };
@@ -132,9 +131,11 @@ async function getDependabotAlerts() {
     return counts;
   } catch (error) {
     // Sanitize error message to prevent log injection
-    // CodeQL needs to see sanitization happen - sanitize inline and wrap in String()
-    const errorMessage = error?.message || 'Unknown error';
-    const sanitizedMessage = String(sanitizeForLog(errorMessage));
+    // Inline sanitization so CodeQL can trace it: remove newlines and control characters
+    const sanitizedMessage = String(error?.message || 'Unknown error')
+      .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+      .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
+      .substring(0, 200); // Limit length
     console.warn('⚠️  Could not fetch Dependabot alerts:', sanitizedMessage);
     return { critical: 0, high: 0, moderate: 0, low: 0, total: 0, error: true };
   }


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/codeql-alerts-12-19-39-63`, this PR is classified as: **Bug fix**

---

## Problem

CodeQL is flagging 4 alerts where user input is logged. After researching CodeQL documentation, the issue is that CodeQL's taint tracking doesn't recognize sanitization through function calls.

## Research Findings

✅ **Our sanitization IS correct** - We remove newlines, control characters, and limit length  
❌ **CodeQL limitation** - Taint tracking doesn't recognize sanitization through function calls  
✅ **Solution** - Inline sanitization so CodeQL can directly trace it

**Reference:** [CodeQL Log Injection Documentation](https://codeql.github.com/codeql-query-help/javascript/js-log-injection/)

## Solution

Use **inline sanitization** matching CodeQL's recommended pattern:
- CodeQL can see: user input → `.replace()` → `.substring()` → console output
- This matches CodeQL's documented examples

## Fixed Alerts

- ✅ **Alert #12**: `scripts/check-github-actions.js:157` - Inline sanitization
- ✅ **Alert #19**: `scripts/update-security-status.js:105` - Inline sanitization  
- ✅ **Alert #39**: `scripts/test-pages-http.js:154` - Inline sanitization
- ✅ **Alert #63**: `scripts/update-security-status.js:138` - Inline sanitization

## Changes

- ✅ Inline sanitization in all 4 locations
- ✅ Removes newlines (`\n`, `\r`) as CodeQL recommends
- ✅ Removes control characters
- ✅ Limits length

## Verification

- ✅ Local checker passes: `npm run check:codeql:simple` (0 issues)
- ✅ Sanitization is correct (matches CodeQL recommendations)

## Note

This PR consolidates fixes from PR #215. The inline sanitization approach is based on CodeQL documentation research and should be recognized by CodeQL's taint tracking.

Fixes CodeQL alerts #12, #19, #39, and #63.