### PR TITLE
fix: Try Copilot's suggested approach with [User Input] prefix for CodeQL

### DIFF
--- a/scripts/test-pages-http.js
+++ b/scripts/test-pages-http.js
@@ -145,15 +145,17 @@ async function runTests() {
       console.log('\nFailed pages:');
       results.filter(r => r.status === 'failed').forEach(r => {
         // Sanitize error message and URL to prevent log injection
-        // Inline sanitization so CodeQL can trace it: remove newlines and control characters
-        // Sanitize directly in console.log arguments so CodeQL can see the sanitization
-        console.log('  -', String(r?.url || '')
+        // Remove newlines and control characters, limit length
+        const sanitizedUrl = String(r?.url || '')
           .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
           .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-          .substring(0, 100), ':', String(r?.error || '') // Limit length
+          .substring(0, 100); // Limit length
+        const sanitizedError = String(r?.error || '')
           .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
           .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-          .substring(0, 200)); // Limit length
+          .substring(0, 200); // Limit length
+        // Use prefix to clearly mark user input in logs
+        console.log('  - [User Input]:', sanitizedUrl, ':', sanitizedError);
       });
       console.log('\n💡 Make sure the server is running: npm start');
       process.exit(1);

--- a/scripts/update-security-status.js
+++ b/scripts/update-security-status.js
@@ -130,12 +130,13 @@ async function getDependabotAlerts() {
     return counts;
   } catch (error) {
     // Sanitize error message to prevent log injection
-    // Inline sanitization so CodeQL can trace it: remove newlines and control characters
-    // Sanitize directly in console.warn argument so CodeQL can see the sanitization
-    console.warn('⚠️  Could not fetch Dependabot alerts:', String(error?.message || 'Unknown error')
+    // Remove newlines and control characters, limit length
+    const sanitizedMessage = String(error?.message || 'Unknown error')
       .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
       .replace(/[\r\n]/g, ' ') // Replace newlines with spaces
-      .substring(0, 200)); // Limit length
+      .substring(0, 200); // Limit length
+    // Use prefix to clearly mark user input in logs
+    console.warn('⚠️  Could not fetch Dependabot alerts: [User Input]:', sanitizedMessage);
     return { critical: 0, high: 0, moderate: 0, low: 0, total: 0, error: true };
   }
 }


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/codeql-copilot-suggestions`, this PR is classified as: **Bug fix**

---

## Problem

CodeQL is still flagging alerts #67 and #68 even with inline sanitization. Copilot Autofix suggests using a different pattern.

## Copilot's Suggestion

Based on Copilot Autofix recommendations:
1. **Use sanitized constants** - Create `sanitizedMessage`, `sanitizedUrl`, `sanitizedError` variables
2. **Add [User Input] prefix** - Clearly mark user input in log lines to help CodeQL recognize sanitization
3. **Separate sanitization from logging** - This may help CodeQL's taint tracking

## Changes

- ✅ `scripts/update-security-status.js:135` - Use `sanitizedMessage` constant with `[User Input]:` prefix
- ✅ `scripts/test-pages-http.js:153` - Use `sanitizedUrl` and `sanitizedError` constants with `[User Input]:` prefix

## Why This Might Work

1. **Clear separation**: Sanitization happens in one place, logging in another
2. **Prefix marking**: `[User Input]:` prefix helps identify sanitized user input
3. **Copilot recommendation**: This matches GitHub Copilot's Autofix suggestions

## Verification

- ✅ Local checker passes: `npm run check:codeql:simple` (0 issues)
- ✅ Sanitization is correct (removes newlines, control chars, limits length)

## Note

This is an experimental approach based on Copilot's suggestions. If CodeQL still flags these, we may need to consider:
- Suppressing as false positives (sanitization is correct)
- Using a different logging approach
- Creating a CodeQL model/library

Fixes CodeQL alerts #67 and #68.