### PR TITLE
fix: Remove non-existent setup-gh action from sync-roadmap workflow

### DIFF
--- a/.github/workflows/sync-roadmap.yml
+++ b/.github/workflows/sync-roadmap.yml
@@ -22,9 +22,6 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       
-      - name: Setup GitHub CLI
-        uses: actions/setup-gh@v1
-      
       - name: Authenticate GitHub CLI
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/sync-roadmap-workflow-error`, this PR is classified as: **Bug fix**

---

## Error Explanation

The milestone sync workflow has been failing nightly with:
```
Unable to resolve action actions/setup-gh, repository not found
```

## Root Cause

The workflow was trying to use `actions/setup-gh@v1` which doesn't exist. GitHub CLI (`gh`) is already pre-installed on GitHub Actions runners, so we only need to authenticate it, not install it.

## Fix Applied

- ✅ Removed the non-existent `actions/setup-gh@v1` step
- ✅ Kept only the authentication step (which is all we need)

This matches the fix we applied to the `update-security-status` workflow earlier.

## Testing

The workflow should now run successfully at 2 AM UTC daily when it syncs the roadmap from GitHub Milestones.