### PR TITLE
fix(ci): add concurrency to workflows to reduce runner acquisition failures

### DIFF
--- a/.github/workflows/branch-protection-check.yml
+++ b/.github/workflows/branch-protection-check.yml
@@ -1,5 +1,9 @@
 name: Branch Protection Check
 
+concurrency:
+  group: branch-protection-check
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,10 @@
 name: Check Links
 
+# Avoid many concurrent runs; re-run failed jobs if you see "job was not acquired by Runner" or "Internal server error" (transient GitHub issues)
+concurrency:
+  group: check-links
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,5 +1,9 @@
 name: CodeQL Analysis
 
+concurrency:
+  group: codeql-analysis
+  cancel-in-progress: true
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,5 +1,9 @@
 name: Lighthouse CI
 
+concurrency:
+  group: lighthouse-ci
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,5 +1,9 @@
 name: Lint Markdown
 
+concurrency:
+  group: lint-markdown
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/pr-auto-fill-template.yml
+++ b/.github/workflows/pr-auto-fill-template.yml
@@ -1,5 +1,9 @@
 name: Auto-fill PR Template
 
+concurrency:
+  group: pr-auto-fill-template
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]

--- a/.github/workflows/pr-auto-label.yml
+++ b/.github/workflows/pr-auto-label.yml
@@ -1,5 +1,9 @@
 name: Auto-label PR by Branch Name
 
+concurrency:
+  group: pr-auto-label
+  cancel-in-progress: true
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,5 +1,9 @@
 name: Spell Check
 
+concurrency:
+  group: spell-check
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/test-codeql-fixes.yml
+++ b/.github/workflows/test-codeql-fixes.yml
@@ -1,5 +1,9 @@
 name: Test CodeQL Fixes
 
+concurrency:
+  group: test-codeql-fixes
+  cancel-in-progress: true
+
 on:
   pull_request:
     branches: [ "main" ]

--- a/.github/workflows/verify-deployment.yml
+++ b/.github/workflows/verify-deployment.yml
@@ -1,5 +1,9 @@
 name: Verify Deployment
 
+concurrency:
+  group: verify-deployment
+  cancel-in-progress: true
+
 on:
   workflow_run:
     workflows: ["Deploy to GitHub Pages"]

--- a/_process/documentation/GITHUB_ACTIONS_TROUBLESHOOTING.md
+++ b/_process/documentation/GITHUB_ACTIONS_TROUBLESHOOTING.md
@@ -79,6 +79,24 @@ GITHUB_TOKEN=your_token node scripts/check-github-actions.js
 3. Expand each step to see error details
 4. Look for red X marks indicating failed steps
 
+### 6. "The job was not acquired by Runner of type hosted even after multiple attempts"
+
+**Cause:** GitHub’s hosted runner pool was temporarily unavailable or at capacity (infrastructure/transient).
+
+**Fix:**
+1. **Re-run the failed jobs:** Actions → open the failed run → **Re-run failed jobs** (or **Re-run all jobs**).
+2. Check [GitHub Status](https://www.githubstatus.com/) for incidents.
+3. If it happens often, reduce concurrent runs (e.g. use `concurrency:` in workflows so only one run per workflow is active).
+
+### 7. "Internal server error" (Check Links or other jobs)
+
+**Cause:** Transient GitHub Actions service error ([GitHub’s troubleshooting](https://docs.github.com/en/actions/how-tos/troubleshoot-workflows)).
+
+**Fix:**
+1. **Re-run the workflow or failed jobs** (same as above).
+2. Check [GitHub Status](https://www.githubstatus.com/).
+3. If it keeps failing, enable debug: Settings → Actions → add secrets `ACTIONS_STEP_DEBUG` and `ACTIONS_RUNNER_DEBUG` = `true`, then re-run and inspect logs.
+
 ---
 
 ## Workflow File Checks
@@ -159,5 +177,5 @@ npm run serve
 
 ---
 
-**Last Updated:** November 2025
+**Last Updated:** February 2026
 


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/actions-concurrency-reduce-runner-failures`, this PR is classified as: **Bug fix**

---

## Summary
Adds concurrency groups to CI workflows so burst merges (e.g. multiple Dependabot PRs + feature PR) don't queue dozens of runs and trigger "job was not acquired by Runner" / "Internal server error".

## Changes
- **Concurrency** (`cancel-in-progress: true`) on: Branch Protection Check, Check Links, CodeQL Analysis, Lint Markdown, Spell Check, Test CodeQL Fixes, Auto-fill PR Template, Auto-label PR, Lighthouse CI, Verify Deployment.
- **Docs:** GITHUB_ACTIONS_TROUBLESHOOTING.md updated with sections for runner acquisition and internal server errors (re-run, status page, concurrency).

Only the latest run per workflow proceeds; older queued runs are cancelled.

Made with [Cursor](https://cursor.com)