### PR TITLE
fix(ci): open PRs instead of pushing to protected main

### DIFF
--- a/.github/workflows/sync-research-bookmarks.yml
+++ b/.github/workflows/sync-research-bookmarks.yml
@@ -74,8 +74,10 @@ jobs:
             echo "::warning::Climate Change directory not found at $CLIMATE_DIR"
           fi
 
-      - name: Commit and push changes
+      - name: Commit and create PR
         if: steps.update-submodule.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -87,12 +89,20 @@ jobs:
             exit 0
           fi
 
-          git commit -m "chore: update research bookmarks submodule
+          BRANCH_NAME="chore/update-bookmarks-submodule-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          git commit -m "chore: update research bookmarks submodule [skip ci]
 
           - Updated to latest commit from gitea pres/bookmarks
           - Climate Change article count: ${{ steps.count_articles.outputs.article_count }}"
+          git push origin "$BRANCH_NAME"
 
-          git push origin HEAD:main || echo "Push failed (may need manual merge)"
+          gh pr create \
+            --title "chore: update research bookmarks submodule" \
+            --body "Automated submodule sync from gitea pres/bookmarks. Climate Change articles: ${{ steps.count_articles.outputs.article_count }}" \
+            --base main \
+            --head "$BRANCH_NAME" \
+            || echo "PR may already exist or failed to create"
 
       - name: Create summary
         run: |

--- a/.github/workflows/update-last-updated.yml
+++ b/.github/workflows/update-last-updated.yml
@@ -6,56 +6,56 @@ on:
       - main
     paths:
       - 'docs/**/*.md'
-  workflow_dispatch: # Allow manual triggering
+  workflow_dispatch:
 
 jobs:
   update-dates:
     name: Update Last Updated Dates
     runs-on: ubuntu-latest
+    # Skip bot commits to avoid push loops
+    if: github.event_name == 'workflow_dispatch' || !contains(github.event.head_commit.message, '[skip ci]')
     permissions:
       contents: write
       pull-requests: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0 # Need full history for Git dates
+          fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
-      
+
       - name: Configure Git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-      
+
       - name: Update Last Updated dates
         run: |
-          echo "🔄 Updating Last Updated dates from Git commit history..."
+          echo "Updating Last Updated dates from Git commit history..."
           ./scripts/update-last-updated.sh
-      
-      - name: Check for changes
-        id: check-changes
+
+      - name: Commit and create PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "✅ Changes detected, will commit"
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "ℹ️  No changes needed"
-          fi
-      
-      - name: Commit changes
-        if: steps.check-changes.outputs.has_changes == 'true'
-        run: |
-          git add docs/
-          git commit -m "chore: Update Last Updated dates from Git commit history [skip ci]"
-          git push
-      
-      - name: Summary
-        run: |
-          if [ "${{ steps.check-changes.outputs.has_changes }}" == "true" ]; then
-            echo "✅ Last Updated dates have been updated and committed"
-          else
-            echo "ℹ️  All dates are already up to date"
+          if [ -z "$(git status --porcelain docs/)" ]; then
+            echo "No changes to commit"
+            exit 0
           fi
 
+          BRANCH_NAME="chore/update-last-updated-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH_NAME"
+          git add docs/
+          git commit -m "chore: Update Last Updated dates from Git commit history [skip ci]"
+          git push origin "$BRANCH_NAME"
+
+          gh pr create \
+            --title "chore: update Last Updated dates" \
+            --body "Automated update of Last Updated lines in docs/ from git history." \
+            --base main \
+            --head "$BRANCH_NAME" \
+            || echo "PR may already exist or failed to create"
+
+      - name: Summary
+        run: echo "Done. If dates changed, a PR was opened for review and merge."


### PR DESCRIPTION
Update Last Updated and bookmarks sync workflows were rejected by branch protection (GH006). Match update-security-status pattern.

## Description
Merge f643b82bc3bb7cb5108d087aa8ebadc246bf30df into 5d10c855366efb38c1c4722810e25e6e7e52d4c6

## Type of Change


**🤖 Auto-classified:** Based on branch name `fix/workflow-pr-instead-of-push-main`, this PR is classified as: **Bug fix**

**Branch:** `${{ github.head_ref }}`  
**🤖 Auto-detected:** The checkbox below is automatically pre-filled based on your branch name.

<!-- 
Branch naming conventions (auto-detection):
- feature/* → Feature ✅ (auto-checked)
- fix/* → Bug fix ✅ (auto-checked)
- docs/* → Documentation ✅ (auto-checked)
- chore/* → Other (Chore) ✅ (auto-checked)
- refactor/* → Refactoring ✅ (auto-checked)

If your branch doesn't match these patterns, please manually select the appropriate type.
-->

- [ ] Feature <!-- Auto-checked for feature/* branches -->
- [ ] Bug fix <!-- Auto-checked for fix/* branches -->
- [ ] Documentation <!-- Auto-checked for docs/* branches -->
- [ ] Refactoring <!-- Auto-checked for refactor/* branches -->
- [ ] Other (please describe) <!-- Auto-checked for chore/* branches -->

## Related Issue
<!-- Link to related issue if applicable -->
<!-- Closes #X -->

## Testing
<!-- How was this tested? -->
- [x] Tested locally
- [ ] Documentation preview checked (`npm start`)
- [x] Build passes (`npm run build`)
- [ ] Link checks pass (`npm run test:links`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex code (if applicable)
- [ ] Documentation updated (if needed)
- [ ] No breaking changes (or breaking changes documented)
- [x] Changes tested locally
- [ ] Commit messages are clear and descriptive

## Screenshots (if applicable)
<!-- Add screenshots here if visual changes -->

## Additional Notes
<!-- Any additional information, context, or concerns -->

---

**⚠️ Important:** This PR will automatically trigger deployment if merged to `main`. Make sure all checks pass before requesting review.

