### PR TITLE
chore: wire bookmarks-mcp in Cursor

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "bookmarks": {
+      "url": "http://192.168.178.35:7100/sse",
+      "envFile": "${workspaceFolder}/.env",
+      "headers": {
+        "Authorization": "Bearer ${env:BOOKMARKS_MCP_AUTH_TOKEN}"
+      }
+    }
+  }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env in this directory (gitignored). Used by .cursor/mcp.json for bookmarks-mcp.
+# Get the value from Unraid: bookmarks-mcp stack → MCP_AUTH_TOKEN
+BOOKMARKS_MCP_AUTH_TOKEN=

--- a/_process/documentation/CURSOR_BOOKMARKS_MCP.md
+++ b/_process/documentation/CURSOR_BOOKMARKS_MCP.md
@@ -8,9 +8,28 @@ Use this when enriching Eco Balance docs with semantic search over the full book
 - Bearer token set in Unraid (`MCP_AUTH_TOKEN` in compose env)
 - VPN/LAN access from the machine running Cursor
 
-## Cursor MCP config
+## Cursor MCP config (this repo)
 
-Add to Cursor **Settings → MCP** (or project `.cursor/mcp.json` if you use one):
+Project config is already at [.cursor/mcp.json](../../.cursor/mcp.json). It reads the token from an environment variable so secrets stay out of git.
+
+### One-time setup
+
+1. On Unraid, open the **bookmarks-mcp** container → Environment → copy **`MCP_AUTH_TOKEN`** (not the Gitea read token).
+2. In this repo root:
+   ```bash
+   cp .env.example .env
+   # Edit .env and paste: BOOKMARKS_MCP_AUTH_TOKEN=<paste from Unraid>
+   ```
+3. Verify from WSL (must be on your LAN):
+   ```bash
+   ./scripts/verify-bookmarks-mcp.sh
+   ```
+4. **Fully quit and restart Cursor** so it picks up `.env` / MCP config.
+5. **Settings → MCP** → confirm **bookmarks** is connected (green). Open **Output** → **MCP** if it fails.
+
+### Optional: global config
+
+Same block in `~/.cursor/mcp.json` if you want bookmarks-mcp in every project. Prefer the project `.cursor/mcp.json` here so Eco Balance docs and token scope stay together.
 
 ```json
 {
@@ -18,14 +37,18 @@ Add to Cursor **Settings → MCP** (or project `.cursor/mcp.json` if you use one
     "bookmarks": {
       "url": "http://192.168.178.35:7100/sse",
       "headers": {
-        "Authorization": "Bearer YOUR_MCP_AUTH_TOKEN"
+        "Authorization": "Bearer ${env:BOOKMARKS_MCP_AUTH_TOKEN}"
       }
     }
   }
 }
 ```
 
-Replace `YOUR_MCP_AUTH_TOKEN` with the value from your Unraid `bookmarks-mcp` stack (not the Gitea token).
+Export the variable in your shell profile if Cursor does not load `.env` automatically:
+
+```bash
+export BOOKMARKS_MCP_AUTH_TOKEN='paste-from-unraid'
+```
 
 ## Tools to use for Eco Balance work
 

--- a/scripts/verify-bookmarks-mcp.sh
+++ b/scripts/verify-bookmarks-mcp.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Quick check that bookmarks-mcp is reachable with your token.
+# Usage: cp .env.example .env, set BOOKMARKS_MCP_AUTH_TOKEN, then ./scripts/verify-bookmarks-mcp.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env
+  set +a
+fi
+
+URL="${BOOKMARKS_MCP_URL:-http://192.168.178.35:7100}"
+TOKEN="${BOOKMARKS_MCP_AUTH_TOKEN:-}"
+
+if [ -z "$TOKEN" ]; then
+  echo "Set BOOKMARKS_MCP_AUTH_TOKEN in $ROOT/.env (copy from .env.example)."
+  exit 1
+fi
+
+echo "GET $URL/sse (expect 200 or SSE handshake, not 401)..."
+CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Accept: text/event-stream" \
+  --connect-timeout 5 \
+  "$URL/sse" || echo "000")
+
+if [ "$CODE" = "401" ]; then
+  echo "FAIL: 401 unauthorized — token does not match Unraid MCP_AUTH_TOKEN."
+  exit 1
+fi
+
+if [ "$CODE" = "000" ]; then
+  echo "FAIL: could not reach $URL (not on LAN or server down)."
+  exit 1
+fi
+
+echo "OK: HTTP $CODE — bookmarks-mcp auth looks good."
+echo "Restart Cursor (full quit), then check Settings → MCP → bookmarks."


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `chore/cursor-bookmarks-mcp`, this PR is classified as: **Other (Chore)**

---

## Summary

- `.cursor/mcp.json` — SSE to `192.168.178.35:7100`, auth via `BOOKMARKS_MCP_AUTH_TOKEN` from `.env`
- `.env.example` + `scripts/verify-bookmarks-mcp.sh`
- Updated setup doc with one-time steps

## You must do locally

1. `cp .env.example .env`
2. Paste `MCP_AUTH_TOKEN` from Unraid bookmarks-mcp into `.env`
3. `./scripts/verify-bookmarks-mcp.sh`
4. Fully restart Cursor


Made with [Cursor](https://cursor.com)