### PR TITLE
fix(ci): stop bookmark sync from opening a new PR every run

### DIFF
--- a/.github/workflows/sync-research-bookmarks.yml
+++ b/.github/workflows/sync-research-bookmarks.yml
@@ -89,20 +89,30 @@ jobs:
             exit 0
           fi
 
-          BRANCH_NAME="chore/update-bookmarks-submodule-$(date +%Y%m%d-%H%M%S)"
-          git checkout -b "$BRANCH_NAME"
-          git commit -m "chore: update research bookmarks submodule [skip ci]
+          # Reuse a single stable branch so repeated runs update one PR
+          # instead of opening a brand-new PR every 6 hours.
+          BRANCH_NAME="chore/auto-bookmarks-sync"
+          git checkout -B "$BRANCH_NAME"
+          git commit -m "chore: update research bookmarks submodule
 
           - Updated to latest commit from gitea pres/bookmarks
           - Climate Change article count: ${{ steps.count_articles.outputs.article_count }}"
-          git push origin "$BRANCH_NAME"
+          git push --force origin "$BRANCH_NAME"
 
-          gh pr create \
-            --title "chore: update research bookmarks submodule" \
-            --body "Automated submodule sync from gitea pres/bookmarks. Climate Change articles: ${{ steps.count_articles.outputs.article_count }}" \
-            --base main \
-            --head "$BRANCH_NAME" \
-            || echo "PR may already exist or failed to create"
+          # Create the PR only if one isn't already open for this branch.
+          if gh pr view "$BRANCH_NAME" --json state -q '.state' 2>/dev/null | grep -q OPEN; then
+            echo "PR for $BRANCH_NAME already open; force-push updated it."
+          else
+            gh pr create \
+              --title "chore: update research bookmarks submodule" \
+              --body "Automated submodule sync from gitea pres/bookmarks. Climate Change articles: ${{ steps.count_articles.outputs.article_count }}" \
+              --base main \
+              --head "$BRANCH_NAME"
+          fi
+
+          # Auto-merge once required checks pass (no-op if already enabled).
+          gh pr merge "$BRANCH_NAME" --auto --squash --delete-branch \
+            || echo "Could not enable auto-merge (check branch-protection / auto-merge settings)."
 
       - name: Create summary
         run: |


### PR DESCRIPTION
## Problem
The `Sync Research Bookmarks` workflow ran every 6 hours and, on each run with a submodule change, created a **uniquely-timestamped branch** and a **brand-new PR** — none of which ever merged. This accumulated **120+ stale open PRs** (just cleaned up manually).

## Fix
The "Commit and create PR" step now:
- Reuses one stable branch `chore/auto-bookmarks-sync` (`checkout -B` + `push --force`) → at most **one** open bookmark PR at any time.
- Only opens a PR if none is already open for that branch.
- Enables `--auto --squash --delete-branch` so the single PR self-merges once checks pass (gracefully no-ops if auto-merge isn't permitted).
- Drops `[skip ci]` so required checks actually run (auto-merge needs them).

## Follow-up needed (repo settings)
- Enable **Settings → General → Allow auto-merge** for the auto-merge step to work; otherwise the PR caps at 1 but needs a manual merge click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)