### PR TITLE
test(deploy): fix Verify Deployment URLs after #439 refactor

### DIFF
--- a/tests/deployment.spec.js
+++ b/tests/deployment.spec.js
@@ -80,12 +80,12 @@ test.describe('Deployment Verification', () => {
   test('key pages load without errors', async ({ page }) => {
     const keyPages = [
       '/',
-      '/vision-strategy/executive-summary',
-      '/vision-strategy/project-vision',
-      '/operations/restoration-methodology',
-      '/business/business-model',
-      '/resources/quick-reference',
-      '/resources/roadmap',
+      '/our-case/vision',
+      '/our-case/status',
+      '/model/method/reforestation',
+      '/model/economics/revenue',
+      '/evidence',
+      '/research',
     ];
 
     const errors = [];
@@ -171,9 +171,9 @@ test.describe('Deployment Verification', () => {
   test('internal links work', async ({ page }) => {
     // Test specific pages that should have working "Back to Project Hub" links
     const testPages = [
-      '/vision-strategy/project-vision',
-      '/vision-strategy/executive-summary',
-      '/operations/restoration-methodology',
+      '/our-case/vision',
+      '/our-case/status',
+      '/model/method/reforestation',
     ];
     
     const brokenLinks = [];
@@ -231,8 +231,8 @@ test.describe('Deployment Verification', () => {
 
   test('no double horizontal rules', async ({ page }) => {
     const testPages = [
-      '/vision-strategy/project-vision',
-      '/vision-strategy/executive-summary',
+      '/our-case/vision',
+      '/model/method/reforestation',
     ];
     
     const issues = [];
@@ -442,28 +442,28 @@ test.describe('Deployment Verification', () => {
     await page.goto(fullUrl, { waitUntil: 'networkidle', timeout: 30000 });
     expect(isValidDeploymentUrl(page.url())).toBeTruthy();
     
-    // Try to find and click Executive Summary link
-    const execSummaryLink = page.locator('a[href*="executive-summary"]').first();
-    const linkExists = await execSummaryLink.count() > 0;
-    
+    // Try to find and click the Vision link
+    const visionLink = page.locator('a[href*="our-case/vision"]').first();
+    const linkExists = await visionLink.count() > 0;
+
     if (linkExists) {
-      await execSummaryLink.click({ timeout: 10000 });
+      await visionLink.click({ timeout: 10000 });
       await page.waitForLoadState('networkidle', { timeout: 15000 });
       const url = page.url();
-      expect(url).toMatch(/executive-summary|eco-balance-documentation/);
+      expect(url).toMatch(/our-case\/vision|eco-balance-documentation/);
     } else {
       // If link not found, just verify we can navigate directly
-      const execUrl = BASE_URL + '/vision-strategy/executive-summary';
-      await page.goto(execUrl, { waitUntil: 'networkidle', timeout: 30000 });
+      const visionUrl = BASE_URL + '/our-case/vision';
+      await page.goto(visionUrl, { waitUntil: 'networkidle', timeout: 30000 });
       const url = page.url();
-      expect(url).toMatch(/executive-summary|eco-balance-documentation/);
+      expect(url).toMatch(/our-case\/vision|eco-balance-documentation/);
     }
-    
-    // Flow 2: Navigate to resources
+
+    // Flow 2: Navigate to research / model section
     await page.goto(fullUrl, { waitUntil: 'networkidle', timeout: 30000 });
-    const resourcesLink = page.locator('a[href*="resources"], a[href*="roadmap"]').first();
-    if (await resourcesLink.count() > 0) {
-      await resourcesLink.click({ timeout: 10000 });
+    const researchLink = page.locator('a[href*="research"], a[href*="model"]').first();
+    if (await researchLink.count() > 0) {
+      await researchLink.click({ timeout: 10000 });
       await page.waitForLoadState('networkidle', { timeout: 15000 });
       expect(isValidDeploymentUrl(page.url())).toBeTruthy();
     }


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `fix/deployment-test-urls`, this PR is classified as: **Bug fix**

---

## Why
The **Verify Deployment** job has been failing since the #439 refactor (and again on the latest `main`). The Playwright suite in `tests/deployment.spec.js` hardcoded doc URLs that #439 **deleted** — `/vision-strategy/**`, `/operations/**`, `/business/**`, `/resources/**`. Those now 404 on the live site, so each navigation hit the 60s timeout and failed three tests:
- `key pages load without errors`
- `no double horizontal rules`
- `critical user flows work`

## What
Repointed every stale path to the current structure, each verified to return **200** on `https://docs.eco-balance.cc`:

| Old (deleted) | New |
|---|---|
| `/vision-strategy/executive-summary`, `/vision-strategy/project-vision` | `/our-case/vision`, `/our-case/status` |
| `/operations/restoration-methodology` | `/model/method/reforestation` |
| `/business/business-model` | `/model/economics/revenue` |
| `/resources/quick-reference`, `/resources/roadmap` | `/evidence`, `/research` |

## Out of scope (separate issue)
The run also logged CORS errors from `search.eco-balance.cc` — that's the **Meilisearch service being down** (origin returns 500 / Cloudflare 525), not a docs problem. Those console errors clear once the search service is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)