### PR TITLE
chore: re-point bookmarks submodule to squashed history + harden sync

### DIFF
--- a/.github/workflows/sync-research-bookmarks.yml
+++ b/.github/workflows/sync-research-bookmarks.yml
@@ -71,7 +71,10 @@ jobs:
 
           retry git submodule sync --recursive research/bookmarks
           retry git submodule update --init --depth 1 --recursive research/bookmarks
-          retry git submodule update --remote --depth 1 --merge research/bookmarks
+          # Checkout (not --merge): the tracked branch tip is authoritative, and
+          # a plain checkout survives history rewrites (e.g. a squash) that would
+          # otherwise fail with "refusing to merge unrelated histories".
+          retry git submodule update --remote --depth 1 research/bookmarks
 
           SUBMODULE_NEW=$(sub_sha)
           echo "New submodule commit: $SUBMODULE_NEW"

--- a/.github/workflows/sync-research-bookmarks.yml
+++ b/.github/workflows/sync-research-bookmarks.yml
@@ -35,22 +35,45 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          submodules: recursive
+          # Don't clone the submodule here — actions/checkout can't retry a
+          # transient Gitea 502. It's initialised in the retried step below.
+          submodules: false
           fetch-depth: 0
 
-      - name: Update submodule
+      - name: Update submodule (with retry)
         id: update-submodule
         run: |
+          set -e
           echo "Updating research bookmarks submodule..."
 
-          SUBMODULE_OLD=$(git submodule status research/bookmarks 2>/dev/null | awk '{print $1}' || echo "none")
+          # Clean submodule SHA (git prefixes status with -/+/U; strip it).
+          sub_sha() { git submodule status research/bookmarks 2>/dev/null | awk '{print $1}' | sed 's/^[-+U]//'; }
+
+          # Retry Gitea network ops with exponential backoff so a transient
+          # Cloudflare 502/5xx from the self-hosted origin doesn't fail the run.
+          retry() {
+            local max=5 delay=5 attempt=1 status=0
+            until "$@"; do
+              status=$?
+              if [ "$attempt" -ge "$max" ]; then
+                echo "::error::'$*' failed after $attempt attempts (exit $status)."
+                return "$status"
+              fi
+              echo "::warning::Attempt $attempt of '$*' failed (exit $status); retrying in ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+              delay=$((delay * 2))
+            done
+          }
+
+          SUBMODULE_OLD=$(sub_sha); [ -z "$SUBMODULE_OLD" ] && SUBMODULE_OLD="none"
           echo "Current submodule commit: $SUBMODULE_OLD"
 
-          git submodule sync --recursive research/bookmarks
-          git submodule update --init --recursive research/bookmarks
-          git submodule update --remote --merge research/bookmarks
+          retry git submodule sync --recursive research/bookmarks
+          retry git submodule update --init --depth 1 --recursive research/bookmarks
+          retry git submodule update --remote --depth 1 --merge research/bookmarks
 
-          SUBMODULE_NEW=$(git submodule status research/bookmarks | awk '{print $1}')
+          SUBMODULE_NEW=$(sub_sha)
           echo "New submodule commit: $SUBMODULE_NEW"
 
           if [ "$SUBMODULE_OLD" != "$SUBMODULE_NEW" ] && [ "$SUBMODULE_OLD" != "none" ]; then

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = research/bookmarks
 	url = https://gitea.nexus-home.cc/pres/bookmarks.git
 	branch = main
+	shallow = true

--- a/_process/documentation/FEATURE_WISHLIST.md
+++ b/_process/documentation/FEATURE_WISHLIST.md
@@ -494,6 +494,22 @@ Embedded crowdfunding functionality within the documentation site, allowing visi
 
 ---
 
+### Grants / Opportunities Tool
+**Status:** Deferred (build last)
+**Priority:** Low for now
+**Related:** v-next blueprint §6.5 (module suite), Funding & Grants domain (D7)
+
+**Description:**
+An AI tool that hunts funding and income opportunities — grants, carbon credits, energy/solar sales, payments for ecosystem services — and keeps a live, filterable table of them with deadlines and eligibility. Its public face is an "opportunities feed" useful to every project in the space, not just ours. Likely breaks out into its own app under `projects/` when built.
+
+**Why it's deferred:**
+No need yet. It depends on a grant-calls inflow that doesn't exist, and the sequencing principle is core-and-publishing first, modules later — the grants tool explicitly comes last, once the core is polished and there's a real funding push to serve. Captured here so it isn't lost; not scheduled.
+
+**When to revisit:**
+Once we are actively fundraising and the rest of the platform is stable and collaborative. Until then it stays a named backlog item.
+
+---
+
 ## 🔧 Technical Enhancements
 
 ### API for External Integrations


### PR DESCRIPTION
**🤖 Auto-classified:** Based on branch name `chore/bookmarks-squash-repoint`, this PR is classified as: **Other (Chore)**

---

## What
- Re-point `research/bookmarks` submodule to the squashed history base (`1d024f16`).
- Harden `sync-research-bookmarks.yml`:
  - `actions/checkout` no longer clones the submodule (can't retry a transient Gitea 502).
  - Submodule init/update moved to a dedicated step with retry + exponential backoff.
  - Shallow fetch (`--depth 1`) so consumers only pull the latest snapshot.
  - Dropped `--merge` (a plain checkout survives history rewrites like the squash).
- `.gitmodules`: `shallow = true`.
- Add deferred "Grants / Opportunities Tool" entry to the feature wishlist.

## Why
The bookmarks repo had bloated to ~140 MB of auto-sync history, and full clones were
timing out through the Cloudflare tunnel (502s). History was squashed at the source;
this points the submodule at the new base and makes the sync resilient and shallow.