### PR TITLE
fix/signin same tab

### DIFF
--- a/src/components/DocsChatWidget.js
+++ b/src/components/DocsChatWidget.js
@@ -1,0 +1,236 @@
+/**
+ * Docs chat widget — a floating "chat with the docs" assistant.
+ *
+ * Talks to the eco-balance-mcp service (POST /api/chat) which runs an agentic
+ * search_docs loop over the model/case corpus and returns a grounded answer +
+ * sources. The endpoint is gated by Cloudflare Access (same as search), so we
+ * probe /health first and show one of:
+ *   - ready  : reachable + authenticated -> floating chat bubble
+ *   - signin : Access redirect / 401/403 -> a "Sign in to chat" bubble
+ *   - hidden : unreachable -> nothing
+ * Select text anywhere on a page and an "Ask about this" chip lets you drop the
+ * selection into the chat as a quoted snippet (sent as `quotes` to the backend).
+ */
+
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
+
+function getEnvVar(name, fallback) {
+  if (typeof window !== 'undefined' && window[name]) return window[name];
+  if (typeof process !== 'undefined' && process.env && process.env[name]) return process.env[name];
+  return fallback;
+}
+
+const CHAT_HOST = getEnvVar('DOCS_CHAT_HOST', 'https://docs-chat.eco-balance.cc');
+const LOGIN_URL = getEnvVar('DOCS_CHAT_LOGIN_URL', CHAT_HOST);
+
+const wrap = { position: 'fixed', right: 20, bottom: 20, zIndex: 500, fontsize: 14 };
+const bubble = {
+  width: 52, height: 52, borderRadius: '50%', border: 'none', cursor: 'pointer',
+  background: 'var(--ifm-color-primary)', color: '#fff', fontSize: 22, boxShadow: '0 4px 14px rgba(0,0,0,.25)',
+};
+const panel = {
+  width: 'min(380px, calc(100vw - 32px))', height: 'min(560px, calc(100vh - 120px))',
+  display: 'flex', flexDirection: 'column', borderRadius: 12, overflow: 'hidden',
+  background: 'var(--ifm-background-surface-color, var(--ifm-background-color))',
+  border: '1px solid var(--ifm-color-emphasis-300)', boxShadow: '0 10px 30px rgba(0,0,0,.3)',
+};
+
+export default function DocsChatWidget() {
+  const [access, setAccess] = useState('checking'); // checking | ready | signin | hidden
+  const [open, setOpen] = useState(false);
+  const [messages, setMessages] = useState([]); // {role:'user'|'assistant', content, sources?}
+  const [quotes, setQuotes] = useState([]); // {text, url}
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [sel, setSel] = useState(null); // { text, x, y }
+  const scrollRef = useRef(null);
+
+  // --- Access probe (mirrors the search bar) --------------------------------
+  const probe = useCallback(() => {
+    let active = true;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 4000);
+    fetch(`${CHAT_HOST}/health`, { method: 'GET', credentials: 'include', redirect: 'manual', cache: 'no-store', signal: controller.signal })
+      .then((r) => {
+        if (!active) return;
+        if (r.type === 'opaqueredirect' || r.status === 401 || r.status === 403) setAccess('signin');
+        else if (r.ok) setAccess('ready');
+        else setAccess('hidden');
+      })
+      .catch(() => { if (active) setAccess('hidden'); })
+      .finally(() => clearTimeout(timer));
+    return () => { active = false; controller.abort(); };
+  }, []);
+
+  useEffect(() => {
+    const cancel = probe();
+    if (!ExecutionEnvironment.canUseDOM) return cancel;
+    const onFocus = () => probe();
+    window.addEventListener('focus', onFocus);
+    return () => { cancel(); window.removeEventListener('focus', onFocus); };
+  }, [probe]);
+
+  // --- Highlight-to-quote ---------------------------------------------------
+  useEffect(() => {
+    if (!ExecutionEnvironment.canUseDOM || access !== 'ready') return undefined;
+    const onMouseUp = () => {
+      const s = window.getSelection && window.getSelection();
+      const text = s ? String(s).trim() : '';
+      if (!s || s.isCollapsed || text.length < 12) { setSel(null); return; }
+      // Ignore selections inside the widget itself.
+      const anchor = s.anchorNode && (s.anchorNode.nodeType === 1 ? s.anchorNode : s.anchorNode.parentElement);
+      if (anchor && anchor.closest && anchor.closest('.docs-chat-widget')) { setSel(null); return; }
+      let rect;
+      try { rect = s.getRangeAt(0).getBoundingClientRect(); } catch { rect = null; }
+      if (!rect || (!rect.width && !rect.height)) { setSel(null); return; }
+      setSel({ text: text.slice(0, 1200), x: Math.min(rect.left + rect.width / 2, window.innerWidth - 130), y: rect.top - 8 });
+    };
+    const onScroll = () => setSel(null);
+    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('scroll', onScroll, true);
+    return () => { document.removeEventListener('mouseup', onMouseUp); document.removeEventListener('scroll', onScroll, true); };
+  }, [access]);
+
+  useEffect(() => {
+    if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [messages, loading, open]);
+
+  const addQuote = () => {
+    if (!sel) return;
+    const url = ExecutionEnvironment.canUseDOM ? window.location.href.split('#')[0] : '';
+    setQuotes((q) => (q.length >= 20 ? q : [...q, { text: sel.text, url }]));
+    setSel(null);
+    setOpen(true);
+    if (ExecutionEnvironment.canUseDOM) window.getSelection()?.removeAllRanges();
+  };
+
+  const send = async () => {
+    const q = input.trim();
+    if ((!q && quotes.length === 0) || loading) return;
+    const userMsg = { role: 'user', content: q || '(see the quoted passage)' };
+    const history = [...messages, userMsg].map(({ role, content }) => ({ role, content }));
+    setMessages((m) => [...m, userMsg]);
+    setInput('');
+    setLoading(true);
+    const sentQuotes = quotes;
+    setQuotes([]);
+    try {
+      const res = await fetch(`${CHAT_HOST}/api/chat`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: history, quotes: sentQuotes }),
+      });
+      if (res.status === 401 || res.status === 403 || res.type === 'opaqueredirect') {
+        setAccess('signin'); setLoading(false); return;
+      }
+      const data = await res.json().catch(() => ({}));
+      if (data && data.answer) {
+        setMessages((m) => [...m, { role: 'assistant', content: data.answer, sources: data.sources || [] }]);
+      } else {
+        setMessages((m) => [...m, { role: 'assistant', content: '⚠️ ' + (data.error || 'Something went wrong.'), sources: [] }]);
+      }
+    } catch {
+      setMessages((m) => [...m, { role: 'assistant', content: '⚠️ Could not reach the assistant.', sources: [] }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (access === 'checking' || access === 'hidden') {
+    // Still render the selection chip only when ready; nothing otherwise.
+    return null;
+  }
+
+  return (
+    <div className="docs-chat-widget" style={wrap}>
+      {/* Ask-about-this chip near a text selection */}
+      {access === 'ready' && sel && (
+        <button
+          onClick={addQuote}
+          style={{
+            position: 'fixed', left: sel.x, top: Math.max(sel.y, 8), transform: 'translate(-50%, -100%)',
+            zIndex: 600, padding: '4px 10px', borderRadius: 6, border: 'none', cursor: 'pointer',
+            background: 'var(--ifm-color-primary)', color: '#fff', fontSize: 12, boxShadow: '0 2px 8px rgba(0,0,0,.25)',
+          }}
+        >
+          💬 Ask about this
+        </button>
+      )}
+
+      {open ? (
+        <div style={panel}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', background: 'var(--ifm-color-primary)', color: '#fff' }}>
+            <strong>Ask the docs</strong>
+            <button onClick={() => setOpen(false)} style={{ background: 'none', border: 'none', color: '#fff', fontSize: 18, cursor: 'pointer' }} aria-label="Close">×</button>
+          </div>
+
+          <div ref={scrollRef} style={{ flex: 1, overflowY: 'auto', padding: 12 }}>
+            {access === 'signin' ? (
+              <div style={{ padding: 12, textAlign: 'center' }}>
+                <p style={{ marginBottom: 8 }}>The assistant is available to signed-in users.</p>
+                <a href={LOGIN_URL} target="_blank" rel="noopener noreferrer">Sign in to chat</a>
+              </div>
+            ) : (
+              <>
+                {messages.length === 0 && (
+                  <p style={{ opacity: 0.65, fontSize: 13 }}>
+                    Ask anything about the model or our case. Tip: select text on a page and click “Ask about this” to quote it.
+                  </p>
+                )}
+                {messages.map((m, i) => (
+                  <div key={i} style={{ margin: '10px 0', display: 'flex', justifyContent: m.role === 'user' ? 'flex-end' : 'flex-start' }}>
+                    <div style={{
+                      maxWidth: '85%', padding: '8px 12px', borderRadius: 10, fontSize: 14, lineHeight: 1.45,
+                      background: m.role === 'user' ? 'var(--ifm-color-primary)' : 'var(--ifm-color-emphasis-100)',
+                      color: m.role === 'user' ? '#fff' : 'inherit', whiteSpace: 'pre-wrap',
+                    }}>
+                      {m.content}
+                      {m.role === 'assistant' && m.sources && m.sources.length > 0 && (
+                        <div style={{ marginTop: 8, borderTop: '1px solid var(--ifm-color-emphasis-200)', paddingTop: 6, fontSize: 12 }}>
+                          <div style={{ opacity: 0.6, marginBottom: 2 }}>Sources</div>
+                          {m.sources.slice(0, 6).map((s, j) => (
+                            <div key={j}><a href={s.url}>{s.title || s.url}</a></div>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                {loading && <div style={{ opacity: 0.6, fontSize: 13 }}>Thinking…</div>}
+              </>
+            )}
+          </div>
+
+          {access === 'ready' && (
+            <div style={{ borderTop: '1px solid var(--ifm-color-emphasis-200)', padding: 8 }}>
+              {quotes.length > 0 && (
+                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 6 }}>
+                  {quotes.map((qt, i) => (
+                    <span key={i} title={qt.text} style={{ fontSize: 11, background: 'var(--ifm-color-emphasis-200)', borderRadius: 6, padding: '2px 6px', maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      “{qt.text}”
+                      <button onClick={() => setQuotes((q) => q.filter((_, k) => k !== i))} style={{ marginLeft: 4, border: 'none', background: 'none', cursor: 'pointer' }}>×</button>
+                    </span>
+                  ))}
+                </div>
+              )}
+              <div style={{ display: 'flex', gap: 6 }}>
+                <input
+                  value={input}
+                  onChange={(e) => setInput(e.target.value)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); send(); } }}
+                  placeholder="Ask about the docs…"
+                  style={{ flex: 1, padding: '8px 10px', borderRadius: 8, border: '1px solid var(--ifm-color-emphasis-300)', fontSize: 14 }}
+                />
+                <button onClick={send} disabled={loading} style={{ padding: '0 14px', borderRadius: 8, border: 'none', cursor: 'pointer', background: 'var(--ifm-color-primary)', color: '#fff' }}>Send</button>
+              </div>
+            </div>
+          )}
+        </div>
+      ) : (
+        <button style={bubble} onClick={() => setOpen(true)} aria-label="Ask the docs" title="Ask the docs">💬</button>
+      )}
+    </div>
+  );
+}

--- a/src/components/DocsChatWidget.js
+++ b/src/components/DocsChatWidget.js
@@ -170,7 +170,7 @@ export default function DocsChatWidget() {
             {access === 'signin' ? (
               <div style={{ padding: 12, textAlign: 'center' }}>
                 <p style={{ marginBottom: 8 }}>The assistant is available to signed-in users.</p>
-                <a href={LOGIN_URL} target="_blank" rel="noopener noreferrer">Sign in to chat</a>
+                <a href={LOGIN_URL}>Sign in to chat</a>
               </div>
             ) : (
               <>

--- a/src/components/MeilisearchSearchBar.js
+++ b/src/components/MeilisearchSearchBar.js
@@ -1,14 +1,20 @@
 /**
- * Meilisearch search bar for Docusaurus.
+ * Docs search bar for Docusaurus.
  *
- * The search service is gated behind Cloudflare Access. On mount we probe it
- * and pick one of three states:
+ * Queries the eco-balance-mcp service's REST search (GET /api/v1/search) — the
+ * SAME Access-gated host as the chat widget (docs-chat.eco-balance.cc). We used
+ * to hit Meilisearch directly, but Meili answers with `Access-Control-Allow-
+ * Origin: *`, which browsers reject on credentialed (cookie-bearing) requests.
+ * The mcp service sets an origin-specific CORS header, so credentialed reads
+ * work — and because it's the same host as chat, one Cloudflare Access sign-in
+ * covers both. Search itself is the hybrid Qdrant + Meili fusion with rerank.
+ *
+ * On mount we probe /health and pick one of:
  *   - ready   : reachable + authenticated  -> show the search box
  *   - signin  : Access redirect / 401 / 403 -> show a "Sign in to search" link
- *               (opens the Access login; search appears after signing in)
- *   - hidden  : unreachable (container down / unconfigured) -> render nothing
- * We re-probe when the tab regains focus, so signing in another tab upgrades
- * signin -> ready without a manual reload. No console noise on failure.
+ *   - hidden  : unreachable (service down)  -> render nothing
+ * We re-probe when the tab regains focus, so signing in upgrades signin -> ready
+ * without a manual reload. No console noise on failure.
  */
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
@@ -20,10 +26,9 @@ function getEnvVar(name, fallback) {
   return fallback;
 }
 
-const HOST = getEnvVar('MEILISEARCH_HOST', 'https://search.eco-balance.cc');
-const KEY = getEnvVar('MEILISEARCH_SEARCH_KEY', 'e1eebc3950796ae3ead1c39d2c80f4148212c344a36fb6ba9e9ec91d7a7f4489');
-const LOGIN_URL = getEnvVar('MEILISEARCH_LOGIN_URL', HOST);
-const INDEX = 'eco-balance-docs';
+// Same host as the chat widget — one Access app / one cookie covers both.
+const HOST = getEnvVar('DOCS_SEARCH_HOST', 'https://docs-chat.eco-balance.cc');
+const LOGIN_URL = getEnvVar('DOCS_SEARCH_LOGIN_URL', HOST);
 
 export default function MeilisearchSearchBar() {
   const [access, setAccess] = useState('checking'); // checking | ready | signin | hidden
@@ -33,11 +38,11 @@ export default function MeilisearchSearchBar() {
   const [isLoading, setIsLoading] = useState(false);
   const searchRef = useRef(null);
 
-  // Probe the (Access-gated) search host. credentials:'include' carries the
+  // Probe the (Access-gated) mcp host. credentials:'include' carries the
   // CF_Authorization cookie; redirect:'manual' turns the Access login redirect
   // into an opaqueredirect we can detect without needing CORS on that response.
   const probe = useCallback(() => {
-    if (!HOST || !KEY) { setAccess('hidden'); return () => {}; }
+    if (!HOST) { setAccess('hidden'); return () => {}; }
     let active = true;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 4000);
@@ -89,7 +94,9 @@ export default function MeilisearchSearchBar() {
     };
   }, [access]);
 
-  // Debounced search (credentials:'include' so the Access cookie rides along).
+  // Debounced search against the mcp REST endpoint (GET /api/v1/search).
+  // credentials:'include' so the Access cookie rides along; the response is a
+  // JSON array of DocHit { title, url, domain, snippet, matched_section, ... }.
   useEffect(() => {
     if (access !== 'ready') return undefined;
     const id = setTimeout(async () => {
@@ -99,19 +106,19 @@ export default function MeilisearchSearchBar() {
       try {
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), 8000);
-        const res = await fetch(`${HOST}/indexes/${INDEX}/search`, {
-          method: 'POST',
+        const res = await fetch(`${HOST}/api/v1/search?q=${encodeURIComponent(q)}&limit=10`, {
+          method: 'GET',
           credentials: 'include',
-          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${KEY}` },
-          body: JSON.stringify({ q, limit: 10, attributesToHighlight: ['title', 'content', 'headings'] }),
+          redirect: 'manual',
+          cache: 'no-store',
           signal: controller.signal,
         });
         clearTimeout(timer);
         if (res.status === 401 || res.status === 403 || res.type === 'opaqueredirect') {
           setAccess('signin'); setResults([]); return; // session expired mid-use
         }
-        const data = res.ok ? await res.json() : { hits: [] };
-        setResults(data.hits || []);
+        const data = res.ok ? await res.json() : [];
+        setResults(Array.isArray(data) ? data : []);
       } catch {
         setResults([]);
       } finally {
@@ -169,22 +176,25 @@ export default function MeilisearchSearchBar() {
             <div>
               {results.map((hit, i) => (
                 <div
-                  key={i}
+                  key={hit.doc_id || i}
                   onClick={() => go(hit.url)}
                   style={{ padding: '12px 16px', cursor: 'pointer', borderBottom: '1px solid var(--ifm-color-emphasis-200)', transition: 'background-color 0.2s' }}
                   onMouseEnter={(e) => { e.currentTarget.style.backgroundColor = 'var(--ifm-color-emphasis-100)'; }}
                   onMouseLeave={(e) => { e.currentTarget.style.backgroundColor = 'transparent'; }}
                 >
-                  <div
-                    style={{ fontWeight: 'bold', marginBottom: 4, color: 'var(--ifm-color-primary)' }}
-                    dangerouslySetInnerHTML={{ __html: hit._formatted?.title || hit.title }}
-                  />
+                  <div style={{ fontWeight: 'bold', marginBottom: 4, color: 'var(--ifm-color-primary)' }}>
+                    {hit.title}
+                    {hit.matched_section && (
+                      <span style={{ fontWeight: 'normal', fontSize: 12, color: 'var(--ifm-color-emphasis-600)' }}>
+                        {' '}› {hit.matched_section}
+                      </span>
+                    )}
+                  </div>
                   <div style={{ fontSize: 12, color: 'var(--ifm-color-emphasis-600)', marginBottom: 4 }}>{hit.url}</div>
-                  {hit._formatted?.content && (
-                    <div
-                      style={{ fontSize: 13, color: 'var(--ifm-color-emphasis-700)', lineHeight: 1.4 }}
-                      dangerouslySetInnerHTML={{ __html: hit._formatted.content.substring(0, 150) + '…' }}
-                    />
+                  {hit.snippet && (
+                    <div style={{ fontSize: 13, color: 'var(--ifm-color-emphasis-700)', lineHeight: 1.4 }}>
+                      {hit.snippet.length > 160 ? hit.snippet.slice(0, 160) + '…' : hit.snippet}
+                    </div>
                   )}
                 </div>
               ))}

--- a/src/components/MeilisearchSearchBar.js
+++ b/src/components/MeilisearchSearchBar.js
@@ -134,8 +134,6 @@ export default function MeilisearchSearchBar() {
       <a
         className="meilisearch-signin navbar__item"
         href={LOGIN_URL}
-        target="_blank"
-        rel="noopener noreferrer"
         title="Search is available to signed-in users"
         style={{ fontSize: 14, whiteSpace: 'nowrap' }}
       >

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,21 @@
+/**
+ * Swizzled Root wrapper — renders the app plus the global "chat with the docs"
+ * floating widget on every page. BrowserOnly keeps it out of SSR (the widget
+ * uses window/fetch and probes the Access-gated chat backend at runtime).
+ */
+import React from 'react';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+
+export default function Root({ children }) {
+  return (
+    <>
+      {children}
+      <BrowserOnly>
+        {() => {
+          const DocsChatWidget = require('@site/src/components/DocsChatWidget').default;
+          return <DocsChatWidget />;
+        }}
+      </BrowserOnly>
+    </>
+  );
+}


### PR DESCRIPTION
- **feat(chat): floating docs assistant widget with highlight-to-quote**
- **fix(auth): open search/chat sign-in in the same tab (redirect rule returns to docs)**
- **refactor(search): query mcp /api/v1/search on the chat host (fixes Meili CORS-with-credentials; one Access login covers search+chat)**
