### PR TITLE
fix/selection menu

### DIFF
--- a/src/components/AnnotationLayer.js
+++ b/src/components/AnnotationLayer.js
@@ -93,6 +93,14 @@ export default function AnnotationLayer() {
     setOpen(true);
   };
 
+  // Fire the shared "ask the docs" event the chat widget listens for, so both
+  // actions live in one on-selection menu instead of two overlapping chips.
+  const askDocs = (text) => {
+    if (!ExecutionEnvironment.canUseDOM || !text) return;
+    const url = window.location.href.split('#')[0];
+    window.dispatchEvent(new CustomEvent('eco:ask-selection', { detail: { text, url } }));
+  };
+
   // --- Text selection -> chip ----------------------------------------------
   useEffect(() => {
     if (!ExecutionEnvironment.canUseDOM || access !== 'ready') return undefined;
@@ -101,7 +109,7 @@ export default function AnnotationLayer() {
       const text = s ? String(s).trim() : '';
       if (!s || s.isCollapsed || text.length < 6) { setSel(null); return; }
       const node = s.anchorNode && (s.anchorNode.nodeType === 1 ? s.anchorNode : s.anchorNode.parentElement);
-      if (node && node.closest && node.closest('.eco-annot')) { setSel(null); return; }
+      if (node && node.closest && node.closest('.eco-annot, .docs-chat-widget')) { setSel(null); return; }
       let rect; try { rect = s.getRangeAt(0).getBoundingClientRect(); } catch { rect = null; }
       if (!rect || (!rect.width && !rect.height)) { setSel(null); return; }
       setSel({ text: text.slice(0, 1000), x: Math.min(rect.left + rect.width / 2, window.innerWidth - 120), y: rect.top - 8 });
@@ -161,6 +169,7 @@ export default function AnnotationLayer() {
 
   const withText = drafts.filter((d) => d.text.trim()).length;
   const btn = { position: 'fixed', left: 20, bottom: 20, zIndex: 500 };
+  const menuBtn = { padding: '5px 10px', border: 'none', cursor: 'pointer', background: 'var(--ifm-color-primary)', color: '#fff', fontSize: 12, whiteSpace: 'nowrap' };
   const panel = {
     position: 'fixed', left: 20, bottom: 80, zIndex: 500, width: 'min(360px, calc(100vw - 40px))',
     maxHeight: 'min(70vh, 560px)', display: 'flex', flexDirection: 'column', borderRadius: 12, overflow: 'hidden',
@@ -170,13 +179,21 @@ export default function AnnotationLayer() {
 
   return (
     <div className="eco-annot">
-      {/* selection chip */}
+      {/* shared on-selection menu: ask the docs + add a note, side by side */}
       {access === 'ready' && sel && (
-        <button
-          onMouseDown={(e) => { e.preventDefault(); addDraft({ kind: 'selection', quote: sel.text }); setSel(null); if (ExecutionEnvironment.canUseDOM) window.getSelection()?.removeAllRanges(); }}
+        <div
           style={{ position: 'fixed', left: sel.x, top: Math.max(sel.y, 8), transform: 'translate(-50%,-100%)', zIndex: 600,
-            padding: '4px 10px', borderRadius: 6, border: 'none', cursor: 'pointer', background: 'var(--ifm-color-primary)', color: '#fff', fontSize: 12, boxShadow: '0 2px 8px rgba(0,0,0,.25)' }}
-        >✎ Add note</button>
+            display: 'flex', gap: 1, borderRadius: 6, overflow: 'hidden', boxShadow: '0 2px 8px rgba(0,0,0,.25)' }}
+        >
+          <button
+            onMouseDown={(e) => { e.preventDefault(); askDocs(sel.text); setSel(null); if (ExecutionEnvironment.canUseDOM) window.getSelection()?.removeAllRanges(); }}
+            style={{ ...menuBtn, borderRight: '1px solid rgba(255,255,255,.25)' }}
+          >💬 Ask the docs</button>
+          <button
+            onMouseDown={(e) => { e.preventDefault(); addDraft({ kind: 'selection', quote: sel.text }); setSel(null); if (ExecutionEnvironment.canUseDOM) window.getSelection()?.removeAllRanges(); }}
+            style={menuBtn}
+          >✎ Add note</button>
+        </div>
       )}
 
       {/* paragraph pin */}

--- a/src/components/DocsChatWidget.js
+++ b/src/components/DocsChatWidget.js
@@ -43,7 +43,6 @@ export default function DocsChatWidget() {
   const [quotes, setQuotes] = useState([]); // {text, url}
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
-  const [sel, setSel] = useState(null); // { text, x, y }
   const scrollRef = useRef(null);
 
   // --- Access probe (mirrors the search bar) --------------------------------
@@ -71,39 +70,25 @@ export default function DocsChatWidget() {
     return () => { cancel(); window.removeEventListener('focus', onFocus); };
   }, [probe]);
 
-  // --- Highlight-to-quote ---------------------------------------------------
+  // --- Add a quote when the shared selection menu fires "ask the docs" -------
+  // The AnnotationLayer owns the single on-selection popover and dispatches this
+  // event, so the two widgets share one menu rather than overlapping chips.
   useEffect(() => {
-    if (!ExecutionEnvironment.canUseDOM || access !== 'ready') return undefined;
-    const onMouseUp = () => {
-      const s = window.getSelection && window.getSelection();
-      const text = s ? String(s).trim() : '';
-      if (!s || s.isCollapsed || text.length < 12) { setSel(null); return; }
-      // Ignore selections inside the widget itself.
-      const anchor = s.anchorNode && (s.anchorNode.nodeType === 1 ? s.anchorNode : s.anchorNode.parentElement);
-      if (anchor && anchor.closest && anchor.closest('.docs-chat-widget')) { setSel(null); return; }
-      let rect;
-      try { rect = s.getRangeAt(0).getBoundingClientRect(); } catch { rect = null; }
-      if (!rect || (!rect.width && !rect.height)) { setSel(null); return; }
-      setSel({ text: text.slice(0, 1200), x: Math.min(rect.left + rect.width / 2, window.innerWidth - 130), y: rect.top - 8 });
+    if (!ExecutionEnvironment.canUseDOM) return undefined;
+    const onAsk = (e) => {
+      const text = (e.detail && e.detail.text ? String(e.detail.text) : '').trim();
+      if (!text) return;
+      const url = (e.detail && e.detail.url) || window.location.href.split('#')[0];
+      setQuotes((q) => (q.length >= 20 ? q : [...q, { text: text.slice(0, 1200), url }]));
+      setOpen(true);
     };
-    const onScroll = () => setSel(null);
-    document.addEventListener('mouseup', onMouseUp);
-    document.addEventListener('scroll', onScroll, true);
-    return () => { document.removeEventListener('mouseup', onMouseUp); document.removeEventListener('scroll', onScroll, true); };
-  }, [access]);
+    window.addEventListener('eco:ask-selection', onAsk);
+    return () => window.removeEventListener('eco:ask-selection', onAsk);
+  }, []);
 
   useEffect(() => {
     if (scrollRef.current) scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
   }, [messages, loading, open]);
-
-  const addQuote = () => {
-    if (!sel) return;
-    const url = ExecutionEnvironment.canUseDOM ? window.location.href.split('#')[0] : '';
-    setQuotes((q) => (q.length >= 20 ? q : [...q, { text: sel.text, url }]));
-    setSel(null);
-    setOpen(true);
-    if (ExecutionEnvironment.canUseDOM) window.getSelection()?.removeAllRanges();
-  };
 
   const send = async () => {
     const q = input.trim();
@@ -145,20 +130,6 @@ export default function DocsChatWidget() {
 
   return (
     <div className="docs-chat-widget" style={wrap}>
-      {/* Ask-about-this chip near a text selection */}
-      {access === 'ready' && sel && (
-        <button
-          onClick={addQuote}
-          style={{
-            position: 'fixed', left: sel.x, top: Math.max(sel.y, 8), transform: 'translate(-50%, -100%)',
-            zIndex: 600, padding: '4px 10px', borderRadius: 6, border: 'none', cursor: 'pointer',
-            background: 'var(--ifm-color-primary)', color: '#fff', fontSize: 12, boxShadow: '0 2px 8px rgba(0,0,0,.25)',
-          }}
-        >
-          💬 Ask about this
-        </button>
-      )}
-
       {open ? (
         <div style={panel}>
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', background: 'var(--ifm-color-primary)', color: '#fff' }}>


### PR DESCRIPTION
- **feat(chat): floating docs assistant widget with highlight-to-quote (#505)**
- **fix/signin same tab (#506)**
- **fix/signin same tab (#507)**
- **Fix/signin same tab (#508)**
- **docs/wishlist current state (#509)**
- **enrich(biodiversity): natural regeneration on ex-farmland reaches meadow diversity in 10-15y without sowing (Norfolk study; Researcher-added nutrient-legacy caveat) (#510)**
- **chore: add .gitattributes (LF everywhere) + renormalize CRLF files, ending phantom-diff churn (#511)**
- **chore: update research bookmarks submodule (#513)**
- **docs(fleet): formalize the doc-improvement fleet — 6 proposer personas + FLEET manifest; retire ai_skills (#514)**
- **feat(annotations): reader annotation layer — selection + paragraph notes, client drafts, send to /api/annotations (#515)**
- **fix(ui): merge the ask-docs and add-note selection chips into one shared menu**
