### PR TITLE
fix(engines): parse CRLF frontmatter (11 bookmarks were invisible to every engine) + dedupe the feed queue by url

### DIFF
--- a/_engines/_reports/enrichment-worklist.md
+++ b/_engines/_reports/enrichment-worklist.md
@@ -2,13 +2,6 @@
 
 Top 30 unused articles, routed to a suggested domain. Review, place the one-line insight in the doc, and paste the citation. The consistency engine checks the result.
 
-### Abandoned farmland restored to wildflower meadow without sowing seeds
-
-- **Suggested domain:** `template/method/biodiversity` (match 2)
-- **Topic:** Wildflower Meadow Restoration
-- **Summary:** Abandoned farmland can be transformed into wildflower-rich grassland without seeding, as demonstrated by a 10 to 15-year study in Norfolk, UK, which shows that natural recovery is effective and cost-efficient for biodiversity restoration.
-- **Citation:** `[Wildflower Meadow Restoration](research/bookmarks/Climate%20Change/1783427400875.md)`
-
 ### Agrivoltaics Works When Solar Panels Do Farm Work
 
 - **Suggested domain:** `template/site-and-land` (match 1)
@@ -58,75 +51,19 @@ Top 30 unused articles, routed to a suggested domain. Review, place the one-line
 - **Summary:** The article introduces Sustainable Living, a platform that curates and connects various sustainable initiatives in Portugal, making it easier for people to find and engage with these projects. The platform aims to highlight the existing wor
 - **Citation:** `[Sustainable Initiatives](research/bookmarks/Climate%20Change/1783099664547.md)`
 
-### A Floating Solar Farm In The Netherlands Is Having A Big Effect On Underwater Habitats
-
-- **Suggested domain:** `template/method/biodiversity` (match 2)
-- **Topic:** Solar farms
-- **Summary:** A floating solar farm in the Netherlands has created a thriving underwater ecosystem, attracting over 400 fish and nearly 2,000 invertebrates, and providing shade that conserves water. This project demonstrates that solar farms can benefit 
-- **Citation:** `[Solar farms](research/bookmarks/Climate%20Change/1782992437625.md)`
-
-### Summer’s new normal is a hazard that’s testing Europe’s climate resilience
-
-- **Suggested domain:** `template/economics` (match 1)
-- **Topic:** Climate Resilience
-- **Summary:** Europe is experiencing unprecedented heatwaves, with temperatures reaching record highs and causing significant health and economic impacts. Despite warnings from scientists, extreme heat is becoming the new normal, testing Europe's climate
-- **Citation:** `[Climate Resilience](research/bookmarks/Climate%20Change/1782976072573.md)`
-
-### reuters.com
-
-- **Suggested domain:** `template/infrastructure` (match 2)
-- **Topic:** El Niño
-- **Summary:** A powerful El Niño is building, expected to be one of the strongest in decades, and new FAO analysis predicts where drought will hit hardest, aiding in targeted support for farmers and pastoralists to mitigate impacts on global food securit
-- **Citation:** `[El Niño](research/bookmarks/Climate%20Change/1782828012910.md)`
-
-### ‘Living laboratory’: Suffolk agroforestry farm seeks community ownership to survive
-
-- **Suggested domain:** `template/method/reforestation` (match 1)
-- **Topic:** Agroforestry
-- **Summary:** Wakelyns, a pioneering agroforestry farm in Suffolk, is under threat and seeks community ownership to secure its future. The farm, a living laboratory for sustainable farming, showcases diverse crops and micro-enterprises that enhance biodi
-- **Citation:** `[Agroforestry](research/bookmarks/Climate%20Change/1782816753001.md)`
-
-### Pollinator Habitat Turns Unprofitable Acres Into an Asset
-
-- **Suggested domain:** `template/method/biodiversity` (match 4)
-- **Topic:** Pollinator Habitat
-- **Summary:** Indiana farmer Brian Scott turned nine unprofitable acres into pollinator habitat, improving the field's return and creating space for wildlife. The project, supported by the Conservation Reserve Program, reduced input costs and provided an
-- **Citation:** `[Pollinator Habitat](research/bookmarks/Climate%20Change/1782658991398.md)`
-
-### Thirsty desert lizards inspire a new water-harvesting system
-
-- **Suggested domain:** `template/method/water` (match 2)
-- **Topic:** Water harvesting
-- **Summary:** Scientists have discovered how desert horned lizards efficiently extract water from their skin using capillary action and asymmetric jaw movements, which inspired a new water-harvesting system that can clean and collect water from damp soil
-- **Citation:** `[Water harvesting](research/bookmarks/Climate%20Change/1782457491384.md)`
-
-### Perennial grasses as circular strips improve rainfall conservation and crop growth in center pivot agriculture - npj Sustainable Agriculture
-
-- **Suggested domain:** `template/method/water` (match 3)
-- **Topic:** Irrigation Systems
-- **Summary:** This study found that integrating circular buffer strips of native perennial grasses within center pivot irrigation systems significantly improved rainwater conservation and maize growth, reducing water stress and increasing biomass water p
-- **Citation:** `[Irrigation Systems](research/bookmarks/Climate%20Change/1782317798681.md)`
-
-### The case for field stations
-
-- **Suggested domain:** `template/indicators` (match 2)
-- **Topic:** field stations
-- **Summary:** A new BioScience paper argues that tropical field stations are crucial for turning global conservation commitments into local action by providing long-term monitoring, training, and local employment. These stations are essential for validat
-- **Citation:** `[field stations](research/bookmarks/Climate%20Change/1782317720085.md)`
-
 ### The Ecological Intelligence of Sacred Landscapes
 
 - **Suggested domain:** `template/method/water` (match 1)
 - **Topic:** Sacred Landscapes
 - **Summary:** The article highlights how sacred landscapes in India and the SWANA region have long integrated ecological practices through religious and cultural traditions, such as temple tanks and sacred groves, which continue to provide environmental 
-- **Citation:** `[Sacred Landscapes](research/bookmarks/Climate%20Change/1782317661867.md)`
+- **Citation:** `[Sacred Landscapes](research/bookmarks/Climate%20Change/1782317661868.md)`
 
 ### REGENERATING THE BIOREGIONAL COMMONS
 
-- **Suggested domain:** `template/method/biodiversity` (match 2)
-- **Topic:** Bioregional Commons
-- **Summary:** The article argues that the current approach to addressing climate, biodiversity, food, and finance issues is flawed due to a fragmented and technical perspective, which fails to recognize the interconnectedness of these challenges. It prop
-- **Citation:** `[Bioregional Commons](research/bookmarks/Climate%20Change/1782154194930.md)`
+- **Suggested domain:** `template/method/biodiversity` (match 1)
+- **Topic:** Bioregional Approach
+- **Summary:** The article argues that the current approach to addressing climate change, biodiversity loss, and other environmental issues is fragmented and fails to recognize the interconnectedness of these challenges. It proposes a bioregional approach
+- **Citation:** `[Bioregional Approach](research/bookmarks/Climate%20Change/1782154194931.md)`
 
 ### 'Everything has its own order and purpose': The rainforest 'farms' defying modern agriculture
 
@@ -211,4 +148,67 @@ Top 30 unused articles, routed to a suggested domain. Review, place the one-line
 - **Topic:** Conservation
 - **Summary:** A project called Space4Nature used AI and citizen science to restore over 60 hectares of pollinator habitat and develop predictive models for conservation, combining high-resolution satellite imagery and machine learning.
 - **Citation:** `[Conservation](research/bookmarks/Climate%20Change/1780744282976.md)`
+
+### ‘An equal and habitable world is possible’: academics set out sweeping vision for planetary survival
+
+- **Suggested domain:** `template/organization` (match 1)
+- **Topic:** Planetary Survival
+- **Summary:** The World Inequality Lab proposes a comprehensive plan to reduce inequality, increase living standards, and limit global heating to 2C by 2100 through bold policy measures like wealth taxes, reduced working hours, and shifts in economic foc
+- **Citation:** `[Planetary Survival](research/bookmarks/Climate%20Change/1780670499180.md)`
+
+### Encyclopedia of Life
+
+- **Suggested domain:** `template/method/biodiversity` (match 3)
+- **Topic:** Biodiversity
+- **Summary:** The Encyclopedia of Life provides global access to knowledge about life on Earth, including detailed information on various species and their ecological roles. This resource supports biodiversity research and conservation efforts.
+- **Citation:** `[Biodiversity](research/bookmarks/Climate%20Change/1765531706791.md)`
+
+### WOODY MEADOW GUIDELINES - Woody Meadow
+
+- **Suggested domain:** `template/method/reforestation` (match 2)
+- **Topic:** Woody Meadows
+- **Summary:** The guidelines provide detailed information on establishing and managing woody meadows, which can enhance biodiversity and carbon sequestration in urban and rural areas.
+- **Citation:** `[Woody Meadows](research/bookmarks/Climate%20Change/1763280214419.md)`
+
+### Banking on Climate Chaos 2025: Global Bank Fossil Fuel Financing Report
+
+- **Suggested domain:** `template/growth-operations` (match 2)
+- **Topic:** Fossil Fuel Financing
+- **Summary:** The report details the financing activities of the world's 65 largest banks in the fossil fuel sector, highlighting the continued support for fossil fuel expansion despite climate change concerns.
+- **Citation:** `[Fossil Fuel Financing](research/bookmarks/Climate%20Change/1756291430212.md)`
+
+### Causes, Effects & Solutions To Climate Change
+
+- **Suggested domain:** `template/method/reforestation` (match 2)
+- **Topic:** Climate Change
+- **Summary:** The article provides an overview of the causes, effects, and solutions to climate change, breaking down complex concepts into accessible information.
+- **Citation:** `[Climate Change](research/bookmarks/Climate%20Change/1715778390000.md)`
+
+### How drought rewires roots, cutting iron uptake across major food crops
+
+- **Suggested domain:** `template/method/water` (match 1)
+- **Topic:** Plant Nutrition
+- **Summary:** Plants under drought stress reduce their iron uptake, which can affect the nutritional value of crops. This shift also allows certain bacteria to thrive, potentially impacting plant health and global food security.
+- **Citation:** `[Plant Nutrition](research/bookmarks/Climate%20Change/1780485783376.md)`
+
+### In Brazil, a project paying farmers for forests is looking to scale up
+
+- **Suggested domain:** `template/method/reforestation` (match 1)
+- **Topic:** Payment for Ecosystem Services (PES)
+- **Summary:** In Brazil, the CONSERV program pays landowners to protect their legal reserve surplus, avoiding over 30,000 hectares of deforestation. The program is now seeking to scale up by exploring mechanisms such as carbon credits and price premiums 
+- **Citation:** `[Payment for Ecosystem Services (PES)](research/bookmarks/Climate%20Change/1780425212427.md)`
+
+### Trees and greenery can cool cities by as much as 18°C – but only if they’re the right type
+
+- **Suggested domain:** `template/method/reforestation` (match 1)
+- **Topic:** Urban Greening
+- **Summary:** The study found that layered vegetation, combining trees, shrubs, and ground cover, can significantly reduce urban heat stress by up to 18°C in Melbourne, while the wrong type of greening can sometimes increase discomfort, especially in hum
+- **Citation:** `[Urban Greening](research/bookmarks/Climate%20Change/1780303191714.md)`
+
+### A global food crisis is nearing – and the warning signs are buried beneath your feet | BBC Science Focus Magazine
+
+- **Suggested domain:** `template/method/soil` (match 1)
+- **Topic:** Soil Science
+- **Summary:** A new technique called 'soilsmology' uses seismology to map soil properties globally, potentially aiding in food security and climate change mitigation by providing detailed information on soil health and carbon content.
+- **Citation:** `[Soil Science](research/bookmarks/Climate%20Change/1780268834416.md)`
 

--- a/_engines/_reports/feed-queue.json
+++ b/_engines/_reports/feed-queue.json
@@ -1,151 +1,58 @@
 {
-  "generated": "2026-07-13T08:14:56.966Z",
-  "corpus": 512,
-  "used": 55,
-  "unused": 471,
+  "generated": "2026-07-16T10:59:54.039Z",
+  "corpus": 530,
+  "used": 56,
+  "suppressed_duplicates": 18,
+  "duplicates_of_cited": 12,
+  "duplicate_twins_collapsed": 6,
+  "unused": 459,
   "candidates": [
     {
-      "id": "1783427400875",
-      "title": "Abandoned farmland restored to wildflower meadow without sowing seeds",
-      "domain": "phys.org",
-      "downloaded": "2026-07-07T12:39:47.382294",
-      "article_type": "",
-      "url": "https://phys.org/news/2026-07-abandoned-farmland-wildflower-meadow-seeds.html"
-    },
-    {
-      "id": "1783255090319",
-      "title": "Agrivoltaics Works When Solar Panels Do Farm Work",
-      "domain": "cleantechnica.com",
-      "downloaded": "2026-07-05T12:41:20.651824",
-      "article_type": "",
-      "url": "https://cleantechnica.com/2026/07/04/agrivoltaics-works-where-shade-does-farm-work/"
-    },
-    {
-      "id": "1783254716157",
+      "id": "1783254716158",
       "title": "Visualizing Every El Niño and La Niña Since 1979",
       "domain": "www.visualcapitalist.com",
-      "downloaded": "2026-07-05T12:41:12.891903",
-      "article_type": "",
+      "downloaded": "2026-07-05T12:41:13.407638",
+      "article_type": "news",
       "url": "https://www.visualcapitalist.com/cp/visualizing-every-el-nino-and-la-nina-since-1979/"
     },
     {
-      "id": "1783233364305",
-      "title": "A benchmark for how different disturbances influence the loss and recovery of carbon and CO₂ in tropical forests",
-      "domain": "phys.org",
-      "downloaded": "2026-07-05T06:38:20.130839",
-      "article_type": "",
-      "url": "https://phys.org/news/2026-07-benchmark-disturbances-loss-recovery-carbon.html"
-    },
-    {
-      "id": "1783233224645",
-      "title": "Scientist dubbed The Bogfather is restoring peatland to fight climate change",
-      "domain": "www.bbc.com",
-      "downloaded": "2026-07-05T06:38:18.921001",
-      "article_type": "",
-      "url": "https://www.bbc.com/news/articles/cy498d400pro"
-    },
-    {
-      "id": "1783232489803",
+      "id": "1783232489804",
       "title": "Climate change makes western Europe heatwave up to 2.5°C hotter in June, Asia Pacific adopts roadmap to tackle climate, biodiversity and pollution",
       "domain": "www.downtoearth.org.in",
-      "downloaded": "2026-07-05T06:27:48.469296",
-      "article_type": "",
+      "downloaded": "2026-07-05T06:27:48.995335",
+      "article_type": "news",
       "url": "https://www.downtoearth.org.in/climate-change/climate-change-makes-western-europe-heatwave-up-to-25c-hotter-in-june-asia-pacific-adopts-roadmap-to-tackle-climate-biodiversity-and-pollution"
     },
     {
-      "id": "1783191100101",
+      "id": "1783191100102",
       "title": "Rameshwari Jonnalagedda Builds 3D Printed Terracotta Modules Designed to Be Colonized by Nature - 3D Printing Industry",
       "domain": "3dprintingindustry.com",
-      "downloaded": "2026-07-04T18:51:56.662083",
-      "article_type": "",
+      "downloaded": "2026-07-04T19:02:11.377486",
+      "article_type": "news",
       "url": "https://3dprintingindustry.com/news/rameshwari-jonnalagedda-builds-3d-printed-terracotta-modules-designed-to-be-colonized-by-nature-252711/"
     },
     {
-      "id": "1783099664547",
-      "title": "The work is already happening. Here’s where to find it.",
-      "domain": "www.theportugalnews.com",
-      "downloaded": "2026-07-03T17:31:16.417594",
-      "article_type": "",
-      "url": "https://www.theportugalnews.com/news/2026-07-03/the-work-is-already-happening-heres-where-to-find-it/1049366"
-    },
-    {
-      "id": "1782992437625",
-      "title": "A Floating Solar Farm In The Netherlands Is Having A Big Effect On Underwater Habitats",
-      "domain": "www.bgr.com",
-      "downloaded": "2026-07-02T11:50:34.188217",
-      "article_type": "",
-      "url": "https://www.bgr.com/2202377/floating-solar-farm-netherlands-effect-underwater-habitats/"
-    },
-    {
-      "id": "1782976072573",
-      "title": "Summer’s new normal is a hazard that’s testing Europe’s climate resilience",
-      "domain": "www.downtoearth.org.in",
-      "downloaded": "2026-07-02T07:08:25.374228",
-      "article_type": "",
-      "url": "https://www.downtoearth.org.in/climate-change/summers-new-normal-is-a-hazard-thats-testing-europes-climate-resilience"
-    },
-    {
-      "id": "1782828012910",
+      "id": "1782828012911",
       "title": "reuters.com",
       "domain": "www.reuters.com",
-      "downloaded": "2026-06-30T14:08:47.020260",
-      "article_type": "",
+      "downloaded": "2026-06-30T14:08:47.589682",
+      "article_type": "news",
       "url": "https://www.reuters.com/sustainability/el-nio-is-coming-fao-we-know-where-drought-will-hit-hardest--ecmii-2026-06-29/"
     },
     {
-      "id": "1782816753001",
-      "title": "‘Living laboratory’: Suffolk agroforestry farm seeks community ownership to survive",
-      "domain": "www.theguardian.com",
-      "downloaded": "2026-06-30T11:02:00.789093",
-      "article_type": "",
-      "url": "https://www.theguardian.com/environment/2026/jun/30/suffolk-agroforestry-farm-wakelyns-community-ownership-survive"
-    },
-    {
-      "id": "1782658991398",
-      "title": "Pollinator Habitat Turns Unprofitable Acres Into an Asset",
-      "domain": "www.agriculture.com",
-      "downloaded": "2026-06-28T15:10:37.315108",
-      "article_type": "",
-      "url": "https://www.agriculture.com/pollinator-habitat-turns-unprofitable-acres-into-an-asset-12007222"
-    },
-    {
-      "id": "1782457491384",
-      "title": "Thirsty desert lizards inspire a new water-harvesting system",
-      "domain": "phys.org",
-      "downloaded": "2026-06-26T07:05:13.864264",
-      "article_type": "",
-      "url": "https://phys.org/news/2026-06-thirsty-lizards-harvesting.html"
-    },
-    {
-      "id": "1782317798681",
-      "title": "Perennial grasses as circular strips improve rainfall conservation and crop growth in center pivot agriculture - npj Sustainable Agriculture",
-      "domain": "www.nature.com",
-      "downloaded": "2026-06-24T16:25:51.730010",
-      "article_type": "",
-      "url": "https://www.nature.com/articles/s44264-026-00167-4"
-    },
-    {
-      "id": "1782317720085",
-      "title": "The case for field stations",
-      "domain": "news.mongabay.com",
-      "downloaded": "2026-06-24T16:25:50.354315",
-      "article_type": "",
-      "url": "https://news.mongabay.com/2026/06/the-case-for-field-stations/"
-    },
-    {
-      "id": "1782317661867",
+      "id": "1782317661868",
       "title": "The Ecological Intelligence of Sacred Landscapes",
       "domain": "www.archdaily.com",
-      "downloaded": "2026-06-24T16:15:21.708240",
-      "article_type": "",
+      "downloaded": "2026-06-24T16:15:22.290549",
+      "article_type": "news",
       "url": "https://www.archdaily.com/1042553/the-ecological-intelligence-of-sacred-landscapes"
     },
     {
-      "id": "1782154194930",
+      "id": "1782154194931",
       "title": "REGENERATING THE BIOREGIONAL COMMONS",
       "domain": "ernestopvanpeborgh.substack.com",
-      "downloaded": "2026-06-22T18:51:27.001879",
-      "article_type": "",
+      "downloaded": "2026-06-22T18:51:34.943667",
+      "article_type": "opinion",
       "url": "https://ernestopvanpeborgh.substack.com/p/regenerating-the-bioregional-commons"
     },
     {

--- a/_engines/_reports/feed-queue.md
+++ b/_engines/_reports/feed-queue.md
@@ -1,29 +1,17 @@
 # Feed queue
 
-Corpus: 512 Climate Change articles. Already used: 55. Not yet used: 471.
+Corpus: 530 Climate Change articles. Already used: 56. Duplicate captures suppressed: 18 (12 already cited under another entry_id, 6 twin captures collapsed). Not yet used: 459.
 
 Newest unused first (top 40):
 
 | entry_id | title | source | downloaded |
 |---|---|---|---|
-| 1783427400875 | Abandoned farmland restored to wildflower meadow without sowing seeds | phys.org | 2026-07-07 |
-| 1783255090319 | Agrivoltaics Works When Solar Panels Do Farm Work | cleantechnica.com | 2026-07-05 |
-| 1783254716157 | Visualizing Every El Niño and La Niña Since 1979 | www.visualcapitalist.com | 2026-07-05 |
-| 1783233364305 | A benchmark for how different disturbances influence the loss and reco | phys.org | 2026-07-05 |
-| 1783233224645 | Scientist dubbed The Bogfather is restoring peatland to fight climate  | www.bbc.com | 2026-07-05 |
-| 1783232489803 | Climate change makes western Europe heatwave up to 2.5°C hotter in Jun | www.downtoearth.org.in | 2026-07-05 |
-| 1783191100101 | Rameshwari Jonnalagedda Builds 3D Printed Terracotta Modules Designed  | 3dprintingindustry.com | 2026-07-04 |
-| 1783099664547 | The work is already happening. Here’s where to find it. | www.theportugalnews.com | 2026-07-03 |
-| 1782992437625 | A Floating Solar Farm In The Netherlands Is Having A Big Effect On Und | www.bgr.com | 2026-07-02 |
-| 1782976072573 | Summer’s new normal is a hazard that’s testing Europe’s climate resili | www.downtoearth.org.in | 2026-07-02 |
-| 1782828012910 | reuters.com | www.reuters.com | 2026-06-30 |
-| 1782816753001 | ‘Living laboratory’: Suffolk agroforestry farm seeks community ownersh | www.theguardian.com | 2026-06-30 |
-| 1782658991398 | Pollinator Habitat Turns Unprofitable Acres Into an Asset | www.agriculture.com | 2026-06-28 |
-| 1782457491384 | Thirsty desert lizards inspire a new water-harvesting system | phys.org | 2026-06-26 |
-| 1782317798681 | Perennial grasses as circular strips improve rainfall conservation and | www.nature.com | 2026-06-24 |
-| 1782317720085 | The case for field stations | news.mongabay.com | 2026-06-24 |
-| 1782317661867 | The Ecological Intelligence of Sacred Landscapes | www.archdaily.com | 2026-06-24 |
-| 1782154194930 | REGENERATING THE BIOREGIONAL COMMONS | ernestopvanpeborgh.substack.com | 2026-06-22 |
+| 1783254716158 | Visualizing Every El Niño and La Niña Since 1979 | www.visualcapitalist.com | 2026-07-05 |
+| 1783232489804 | Climate change makes western Europe heatwave up to 2.5°C hotter in Jun | www.downtoearth.org.in | 2026-07-05 |
+| 1783191100102 | Rameshwari Jonnalagedda Builds 3D Printed Terracotta Modules Designed  | 3dprintingindustry.com | 2026-07-04 |
+| 1782828012911 | reuters.com | www.reuters.com | 2026-06-30 |
+| 1782317661868 | The Ecological Intelligence of Sacred Landscapes | www.archdaily.com | 2026-06-24 |
+| 1782154194931 | REGENERATING THE BIOREGIONAL COMMONS | ernestopvanpeborgh.substack.com | 2026-06-22 |
 | 1781795484680 | 'Everything has its own order and purpose': The rainforest 'farms' def | www.bbc.com | 2026-06-18 |
 | 1781795186142 | 150 Years Ago, a Super El Niño Killed 50 Million People. The Next One  | www.popularmechanics.com | 2026-06-18 |
 | 1781769407957 | A bonanza for fans of the natural world: the digital library sharing 6 | www.theguardian.com | 2026-06-18 |
@@ -46,3 +34,15 @@ Newest unused first (top 40):
 | 1780303191714 | Trees and greenery can cool cities by as much as 18°C – but only if th | theconversation.com | 2026-06-01 |
 | 1780268834416 | A global food crisis is nearing – and the warning signs are buried ben | www.sciencefocus.com | 2026-05-31 |
 | 1780098862313 | An empirically based dynamic approach to sustainable climate policy de | www.nature.com | 2026-05-30 |
+| 1765529625389 | Ecosystem health shapes viral ecology in peatland soils / Nature Micro | nature.com | 2026-05-30 |
+| 1765015201756 | A place-based assessment of biodiversity intactness in sub-Saharan Afr | nature.com | 2026-05-30 |
+| 1779757241938 | They Kept Planting Trees in the Sahara and Kept Failing. Then They Rel | indiandefencereview.com | 2026-05-26 |
+| 1779188940328 | The Sir Attenborough blueprint: How storytelling became conservation’s | www.afaqs.com | 2026-05-21 |
+| 1779143385167 | Scientists find hidden rainfall pattern that could reshape farming | www.sciencedaily.com | 2026-05-21 |
+| 1779128990528 | What you need to know as pine martens are reintroduced | www.bbc.com | 2026-05-21 |
+| 1779128775688 | Biodiversity continues to decline, 2025 data shows | www.bbc.com | 2026-05-21 |
+| 1779125742565 | This 32-Year-Old Is Rebuilding a Lost Forest in the Western Ghats With | thebetterindia.com | 2026-05-21 |
+| 1779125518612 | Volunteer tree planters aiming to prevent flooding | www.bbc.com | 2026-05-21 |
+| 1779122710688 | Congo’s communities are creating a 1-million-hectare biodiversity corr | news.mongabay.com | 2026-05-21 |
+| 1778655588518 | Today more than ever, biodiversity needs single-species conservation | theconversation.com | 2026-05-18 |
+| 1778655514916 | Humber Forest will grow for decades, say bosses | bbc.com | 2026-05-18 |

--- a/_engines/_reports/health.md
+++ b/_engines/_reports/health.md
@@ -1,12 +1,12 @@
 # Consistency & quality report
 
-Generated 2026-07-13T08:14. Scanned 43 source docs.
+Generated 2026-07-16T11:00. Scanned 43 source docs.
 
 ## Summary
 
 - Broken internal links: 0
-- Unresolved citations: 11
-- Cited articles indexed: 44
+- Unresolved citations: 0
+- Cited articles indexed: 56
 - Voice-tell hits: 0
 - Decision records: 13
 
@@ -14,19 +14,9 @@ Generated 2026-07-13T08:14. Scanned 43 source docs.
 
 None.
 
-## Unresolved citations (11)
+## Unresolved citations (0)
 
-- template/economics/revenue.md -> 1782658991399
-- template/engagement/00-overview.md -> 1783099664548
-- template/indicators/00-overview.md -> 1782317720086
-- template/infrastructure/00-overview.md -> 1783255090320
-- template/method/reforestation.md -> 1783233364306
-- template/method/water.md -> 1782457491385
-- template/method/water.md -> 1782992437626
-- template/method/water.md -> 1782317798682
-- template/method/water.md -> 1783233224646
-- template/risk/00-overview.md -> 1782976072574
-- template/stewardship-handoff/00-overview.md -> 1782816753002
+None.
 
 ## Voice tells to review (0)
 

--- a/_engines/feed/scan.js
+++ b/_engines/feed/scan.js
@@ -31,13 +31,45 @@ for (const base of SRC) for (const f of walk(base)) {
   for (const m of txt.matchAll(/\b(\d{13})\b/g)) cited.add(m[1]); // entry_ids in sources/evidence
 }
 
-const cand = corpus.filter(c => !cited.has(c.id));
+// Dedupe by ARTICLE (url), not just entry_id.
+//
+// The corpus contains duplicate captures of the same article under different
+// (usually adjacent) entry_ids. Upstream fixes stop NEW duplicates being made
+// (bookmarks-bot's check-url probe; bookmarks-mcp's list_urls "dedup surface
+// for the feed engine"), but they can't remove the historical twins already in
+// the corpus — and this engine only ever filtered on entry_id. So citing one
+// twin left the other "unused" forever and the queue kept re-proposing insights
+// that were already placed. Filtering on the url fixes it here, defensively,
+// regardless of what the corpus contains.
+const norm = (u) => String(u || '').trim().replace(/#.*$/, '').replace(/\/+$/, '');
+
+// A URL counts as used if ANY entry sharing it is cited.
+const citedUrls = new Set();
+for (const c of corpus) if (cited.has(c.id) && norm(c.url)) citedUrls.add(norm(c.url));
+
+const rawUnused = corpus.filter(c => !cited.has(c.id));
+let cand = rawUnused.filter(c => !(norm(c.url) && citedUrls.has(norm(c.url))));
+const dupesOfCited = rawUnused.length - cand.length;
+
 cand.sort((a, b) => String(b.downloaded).localeCompare(String(a.downloaded)));
+
+// Collapse twins that are BOTH uncited — keep the newest capture only.
+const seenUrl = new Set();
+const beforeCollapse = cand.length;
+cand = cand.filter((c) => {
+  const u = norm(c.url);
+  if (!u) return true;                 // no url recorded — can't dedupe, keep
+  if (seenUrl.has(u)) return false;    // a newer capture of this article is already queued
+  seenUrl.add(u);
+  return true;
+});
+const dupeTwins = beforeCollapse - cand.length;
+const suppressed = dupesOfCited + dupeTwins;
 
 fs.mkdirSync(OUT, { recursive: true });
 const top = cand.slice(0, 40);
-let md = `# Feed queue\n\nCorpus: ${corpus.length} Climate Change articles. Already used: ${cited.size}. Not yet used: ${cand.length}.\n\nNewest unused first (top ${top.length}):\n\n| entry_id | title | source | downloaded |\n|---|---|---|---|\n`;
+let md = `# Feed queue\n\nCorpus: ${corpus.length} Climate Change articles. Already used: ${cited.size}. Duplicate captures suppressed: ${suppressed} (${dupesOfCited} already cited under another entry_id, ${dupeTwins} twin captures collapsed). Not yet used: ${cand.length}.\n\nNewest unused first (top ${top.length}):\n\n| entry_id | title | source | downloaded |\n|---|---|---|---|\n`;
 for (const c of top) md += `| ${c.id} | ${c.title.slice(0, 70).replace(/\|/g, '/')} | ${c.domain} | ${c.downloaded.slice(0, 10)} |\n`;
 fs.writeFileSync(path.join(OUT, 'feed-queue.md'), md);
-fs.writeFileSync(path.join(OUT, 'feed-queue.json'), JSON.stringify({ generated: new Date().toISOString(), corpus: corpus.length, used: cited.size, unused: cand.length, candidates: cand }, null, 2));
-console.log(`Feed: ${corpus.length} corpus, ${cited.size} used, ${cand.length} unused -> _engines/_reports/feed-queue.md`);
+fs.writeFileSync(path.join(OUT, 'feed-queue.json'), JSON.stringify({ generated: new Date().toISOString(), corpus: corpus.length, used: cited.size, suppressed_duplicates: suppressed, duplicates_of_cited: dupesOfCited, duplicate_twins_collapsed: dupeTwins, unused: cand.length, candidates: cand }, null, 2));
+console.log(`Feed: ${corpus.length} corpus, ${cited.size} used, ${suppressed} duplicate captures suppressed, ${cand.length} unused -> _engines/_reports/feed-queue.md`);

--- a/_engines/lib/common.js
+++ b/_engines/lib/common.js
@@ -12,8 +12,18 @@ function walk(dir, out = []) {
   return out;
 }
 function splitFrontmatter(text) {
-  const m = text.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  return m ? { front: m[1], body: m[2] } : { front: '', body: text };
+  // Normalise CRLF (and a stray BOM) before matching.
+  //
+  // This regex used to require LF, so any file written with \r\n silently fell
+  // through to { front: '' } — the entry then had no parseable entry_id and was
+  // dropped from the corpus entirely, while still being cited in the docs. That
+  // made the feed engine re-propose insights already placed (a "duplicate" that
+  // was really an invisible twin), and it quietly shrank the corpus every engine
+  // sees. The bookmarks submodule is a separate repo, so the docs repo's
+  // .gitattributes never normalised it — parse defensively here instead.
+  const t = String(text).replace(/^﻿/, '').replace(/\r\n/g, '\n');
+  const m = t.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  return m ? { front: m[1], body: m[2] } : { front: '', body: t };
 }
 function frontField(front, key) {
   const m = front.match(new RegExp('^' + key + ':\\s*(.*)$', 'm'));


### PR DESCRIPTION
splitFrontmatter's regex required LF, so any \r\n bookmark silently returned
empty frontmatter, had no entry_id, and was dropped from the corpus while still
being cited - which is why the feed engine kept re-proposing already-placed
insights. Corpus 519 -> 530; 18 duplicate captures now suppressed.
